### PR TITLE
[JDK17] Implement the CLinker downcall handle of JEP389 on PPC64/S390

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/incubator/foreign/CLinker.java
@@ -23,6 +23,13 @@
  *  questions.
  *
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.incubator.foreign;
 
 import jdk.internal.foreign.AbstractCLinker;
@@ -32,6 +39,9 @@ import jdk.internal.foreign.SystemLookup;
 import jdk.internal.foreign.abi.SharedUtils;
 import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64VaList;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64VaList;
+import jdk.internal.foreign.abi.ppc64.aix.AixPPC64VaList;
+import jdk.internal.foreign.abi.ppc64.sysv.SysVPPC64leVaList;
+import jdk.internal.foreign.abi.s390x.sysv.SysVS390xVaList;
 import jdk.internal.foreign.abi.x64.sysv.SysVVaList;
 import jdk.internal.foreign.abi.x64.windows.WinVaList;
 import jdk.internal.reflect.CallerSensitive;
@@ -238,39 +248,39 @@ public sealed interface CLinker permits AbstractCLinker {
     /**
      * The layout for the {@code char} C type
      */
-    ValueLayout C_CHAR = pick(SysV.C_CHAR, Win64.C_CHAR, AArch64.C_CHAR);
+    ValueLayout C_CHAR = pick(SysV.C_CHAR, Win64.C_CHAR, AArch64.C_CHAR, SysVPPC64le.C_CHAR, SysVS390x.C_CHAR, AIX.C_CHAR);
     /**
      * The layout for the {@code short} C type
      */
-    ValueLayout C_SHORT = pick(SysV.C_SHORT, Win64.C_SHORT, AArch64.C_SHORT);
+    ValueLayout C_SHORT = pick(SysV.C_SHORT, Win64.C_SHORT, AArch64.C_SHORT, SysVPPC64le.C_SHORT, SysVS390x.C_SHORT, AIX.C_SHORT);
     /**
      * The layout for the {@code int} C type
      */
-    ValueLayout C_INT = pick(SysV.C_INT, Win64.C_INT, AArch64.C_INT);
+    ValueLayout C_INT = pick(SysV.C_INT, Win64.C_INT, AArch64.C_INT, SysVPPC64le.C_INT, SysVS390x.C_INT, AIX.C_INT);
     /**
      * The layout for the {@code long} C type
      */
-    ValueLayout C_LONG = pick(SysV.C_LONG, Win64.C_LONG, AArch64.C_LONG);
+    ValueLayout C_LONG = pick(SysV.C_LONG, Win64.C_LONG, AArch64.C_LONG, SysVPPC64le.C_LONG, SysVS390x.C_LONG, AIX.C_LONG);
     /**
      * The layout for the {@code long long} C type.
      */
-    ValueLayout C_LONG_LONG = pick(SysV.C_LONG_LONG, Win64.C_LONG_LONG, AArch64.C_LONG_LONG);
+    ValueLayout C_LONG_LONG = pick(SysV.C_LONG_LONG, Win64.C_LONG_LONG, AArch64.C_LONG_LONG, SysVPPC64le.C_LONG_LONG, SysVS390x.C_LONG_LONG, AIX.C_LONG_LONG);
     /**
      * The layout for the {@code float} C type
      */
-    ValueLayout C_FLOAT = pick(SysV.C_FLOAT, Win64.C_FLOAT, AArch64.C_FLOAT);
+    ValueLayout C_FLOAT = pick(SysV.C_FLOAT, Win64.C_FLOAT, AArch64.C_FLOAT, SysVPPC64le.C_FLOAT, SysVS390x.C_FLOAT, AIX.C_FLOAT);
     /**
      * The layout for the {@code double} C type
      */
-    ValueLayout C_DOUBLE = pick(SysV.C_DOUBLE, Win64.C_DOUBLE, AArch64.C_DOUBLE);
+    ValueLayout C_DOUBLE = pick(SysV.C_DOUBLE, Win64.C_DOUBLE, AArch64.C_DOUBLE, SysVPPC64le.C_DOUBLE, SysVS390x.C_DOUBLE, AIX.C_DOUBLE);
     /**
      * The {@code T*} native type.
      */
-    ValueLayout C_POINTER = pick(SysV.C_POINTER, Win64.C_POINTER, AArch64.C_POINTER);
+    ValueLayout C_POINTER = pick(SysV.C_POINTER, Win64.C_POINTER, AArch64.C_POINTER, SysVPPC64le.C_POINTER, SysVS390x.C_POINTER, AIX.C_POINTER);
     /**
      * The layout for the {@code va_list} C type
      */
-    MemoryLayout C_VA_LIST = pick(SysV.C_VA_LIST, Win64.C_VA_LIST, AArch64.C_VA_LIST);
+    MemoryLayout C_VA_LIST = pick(SysV.C_VA_LIST, Win64.C_VA_LIST, AArch64.C_VA_LIST, SysVPPC64le.C_VA_LIST, SysVS390x.C_VA_LIST, AIX.C_VA_LIST);
 
     /**
      * Returns a memory layout that is suitable to use as the layout for variadic arguments in a specialized
@@ -444,7 +454,7 @@ public sealed interface CLinker permits AbstractCLinker {
      * <p> Unless otherwise specified, passing a {@code null} argument, or an array argument containing one or more {@code null}
      * elements to a method in this class causes a {@link NullPointerException NullPointerException} to be thrown. </p>
      */
-    sealed interface VaList extends Addressable permits WinVaList, SysVVaList, LinuxAArch64VaList, MacOsAArch64VaList, SharedUtils.EmptyVaList {
+    sealed interface VaList extends Addressable permits WinVaList, SysVVaList, LinuxAArch64VaList, MacOsAArch64VaList, AixPPC64VaList, SysVPPC64leVaList, SysVS390xVaList, SharedUtils.EmptyVaList {
 
         /**
          * Reads the next value as an {@code int} and advances this va list's position.
@@ -650,7 +660,7 @@ public sealed interface CLinker permits AbstractCLinker {
          * <p> Unless otherwise specified, passing a {@code null} argument, or an array argument containing one or more {@code null}
          * elements to a method in this class causes a {@link NullPointerException NullPointerException} to be thrown. </p>
          */
-        sealed interface Builder permits WinVaList.Builder, SysVVaList.Builder, LinuxAArch64VaList.Builder, MacOsAArch64VaList.Builder {
+        sealed interface Builder permits WinVaList.Builder, SysVVaList.Builder, LinuxAArch64VaList.Builder, MacOsAArch64VaList.Builder, AixPPC64VaList.Builder, SysVPPC64leVaList.Builder, SysVS390xVaList.Builder {
 
             /**
              * Adds a native value represented as an {@code int} to the C {@code va_list} being constructed.

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CABI.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/CABI.java
@@ -23,6 +23,13 @@
  *  questions.
  *
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.foreign;
 
 import sun.security.action.GetPropertyAction;
@@ -34,7 +41,10 @@ public enum CABI {
     SysV,
     Win64,
     LinuxAArch64,
-    MacOsAArch64;
+    MacOsAArch64,
+    SysVPPC64le,
+    SysVS390x,
+    AIX;
 
     private static final CABI current;
 
@@ -57,7 +67,15 @@ public enum CABI {
                 // The Linux ABI follows the standard AAPCS ABI
                 current = LinuxAArch64;
             }
-        } else {
+        } else if (arch.startsWith("ppc64")) {
+            if (os.startsWith("Linux")) {
+                current = SysVPPC64le;
+            } else {
+                current = AIX;
+            }
+         } else if (arch.equals("s390x") && os.startsWith("Linux")) {
+                current = SysVS390x;
+         } else {
             throw new ExceptionInInitializerError(
                 "Unsupported os, arch, or address size: " + os + ", " + arch + ", " + addressSize);
         }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -23,6 +23,13 @@
  *  questions.
  *
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.foreign;
 
 import jdk.incubator.foreign.CLinker;
@@ -32,13 +39,17 @@ import jdk.incubator.foreign.ValueLayout;
 import java.nio.ByteOrder;
 
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.ByteOrder.BIG_ENDIAN;
 
 public class PlatformLayouts {
-    public static <Z extends MemoryLayout> Z pick(Z sysv, Z win64, Z aarch64) {
+    public static <Z extends MemoryLayout> Z pick(Z sysv, Z win64, Z aarch64, Z sysvppc64le, Z sysvs390x, Z aix) {
         return switch (CABI.current()) {
             case SysV -> sysv;
             case Win64 -> win64;
             case LinuxAArch64, MacOsAArch64 -> aarch64;
+            case SysVPPC64le -> sysvppc64le;
+            case SysVS390x -> sysvs390x;
+            case AIX -> aix;
         };
     }
 
@@ -292,5 +303,183 @@ public class PlatformLayouts {
         public static MemoryLayout asVarArg(MemoryLayout layout) {
             return layout.withAttribute(STACK_VARARGS_ATTRIBUTE_NAME, true);
         }
+    }
+
+    /**
+     * This class defines layout constants modelling standard primitive types supported by the PPC64LE SystemV ABI.
+     */
+    public static final class SysVPPC64le {
+        private SysVPPC64le() {
+            //just the one
+        }
+
+        /**
+         * The name of the layout attribute (see {@link MemoryLayout#attributes()} used to mark variadic parameters. The
+         * attribute value must be a boolean.
+         */
+        public final static String VARARGS_ATTRIBUTE_NAME = "abi/SysV/varargs";
+
+        /**
+         * The {@code char} native type.
+         */
+        public static final ValueLayout C_CHAR = ofChar(LITTLE_ENDIAN, 8);
+
+        /**
+         * The {@code short} native type.
+         */
+        public static final ValueLayout C_SHORT = ofShort(LITTLE_ENDIAN, 16);
+
+        /**
+         * The {@code int} native type.
+         */
+        public static final ValueLayout C_INT = ofInt(LITTLE_ENDIAN, 32);
+
+        /**
+         * The {@code long} native type.
+         */
+        public static final ValueLayout C_LONG = ofLong(LITTLE_ENDIAN, 64);
+
+        /**
+         * The {@code long long} native type.
+         */
+        public static final ValueLayout C_LONG_LONG = ofLongLong(LITTLE_ENDIAN, 64);
+
+        /**
+         * The {@code float} native type.
+         */
+        public static final ValueLayout C_FLOAT = ofFloat(LITTLE_ENDIAN, 32);
+
+        /**
+         * The {@code double} native type.
+         */
+        public static final ValueLayout C_DOUBLE = ofDouble(LITTLE_ENDIAN, 64);
+
+        /**
+         * The {@code T*} native type.
+         */
+        public static final ValueLayout C_POINTER = ofPointer(LITTLE_ENDIAN, 64);
+
+        /**
+         * The {@code va_list} native type, as it is passed to a function.
+         */
+        public static final MemoryLayout C_VA_LIST = SysVPPC64le.C_POINTER;
+
+        /**
+         * Return a new memory layout which describes a variadic parameter to be passed to a function.
+         * @param layout the original parameter layout.
+         * @return a layout which is the same as {@code layout}, except for the extra attribute {@link #VARARGS_ATTRIBUTE_NAME},
+         * which is set to {@code true}.
+         */
+        public static MemoryLayout asVarArg(MemoryLayout layout) {
+            return layout.withAttribute(VARARGS_ATTRIBUTE_NAME, true);
+        }
+    }
+
+    /**
+     * This class defines layout constants modelling standard primitive types supported by the s390x SystemV ABI.
+     */
+    public static final class SysVS390x {
+        private SysVS390x() {
+            //just the one
+        }
+
+        /**
+         * The {@code char} native type.
+         */
+        public static final ValueLayout C_CHAR = ofChar(BIG_ENDIAN, 8);
+
+        /**
+         * The {@code short} native type.
+         */
+        public static final ValueLayout C_SHORT = ofShort(BIG_ENDIAN, 16);
+
+        /**
+         * The {@code int} native type.
+         */
+        public static final ValueLayout C_INT = ofInt(BIG_ENDIAN, 32);
+
+        /**
+         * The {@code long} native type.
+         */
+        public static final ValueLayout C_LONG = ofLong(BIG_ENDIAN, 64);
+
+        /**
+         * The {@code long long} native type.
+         */
+        public static final ValueLayout C_LONG_LONG = ofLongLong(BIG_ENDIAN, 64);
+
+        /**
+         * The {@code float} native type.
+         */
+        public static final ValueLayout C_FLOAT = ofFloat(BIG_ENDIAN, 32);
+
+        /**
+         * The {@code double} native type.
+         */
+        public static final ValueLayout C_DOUBLE = ofDouble(BIG_ENDIAN, 64);
+
+        /**
+         * The {@code T*} native type.
+         */
+        public static final ValueLayout C_POINTER = ofPointer(BIG_ENDIAN, 64);
+
+        /**
+         * The {@code va_list} native type, as it is passed to a function.
+         */
+        public static final MemoryLayout C_VA_LIST = SysVS390x.C_POINTER;
+    }
+
+    /**
+     * This class defines layout constants modelling standard primitive types supported by the AIX PPC64 C ABI.
+     */
+    public static final class AIX {
+        private AIX() {
+            //just the one
+        }
+
+        /**
+         * The {@code char} native type.
+         */
+        public static final ValueLayout C_CHAR = ofChar(BIG_ENDIAN, 8);
+
+        /**
+         * The {@code short} native type.
+         */
+        public static final ValueLayout C_SHORT = ofShort(BIG_ENDIAN, 16);
+
+        /**
+         * The {@code int} native type.
+         */
+        public static final ValueLayout C_INT = ofInt(BIG_ENDIAN, 32);
+
+        /**
+         * The {@code long} native type.
+         */
+        public static final ValueLayout C_LONG = ofLong(BIG_ENDIAN, 32);
+
+        /**
+         * The {@code long long} native type.
+         */
+        public static final ValueLayout C_LONG_LONG = ofLongLong(BIG_ENDIAN, 64);
+
+        /**
+         * The {@code float} native type.
+         */
+        public static final ValueLayout C_FLOAT = ofFloat(BIG_ENDIAN, 32);
+
+        /**
+         * The {@code double} native type.
+         */
+        public static final ValueLayout C_DOUBLE = ofDouble(BIG_ENDIAN, 64);
+
+        /**
+         * The {@code T*} native type.
+         */
+        public static final ValueLayout C_POINTER = ofPointer(BIG_ENDIAN, 64);
+
+        /**
+         * The {@code va_list} native type, as it is passed to a function.
+         */
+        public static final MemoryLayout C_VA_LIST = AIX.C_POINTER;
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.foreign;
 
 import jdk.incubator.foreign.MemoryAccess;
@@ -52,9 +58,14 @@ public class SystemLookup implements SymbolLookup {
      * on Windows. For this reason, on Windows we do not generate any side-library, and load msvcrt.dll directly instead.
      */
     private static final SymbolLookup syslookup = switch (CABI.current()) {
-        case SysV, LinuxAArch64, MacOsAArch64 -> libLookup(libs -> libs.loadLibrary("syslookup"));
+        case SysV, LinuxAArch64, MacOsAArch64, SysVPPC64le, SysVS390x -> libLookup(libs -> libs.loadLibrary("syslookup"));
+        case AIX -> makeAixLookup();
         case Win64 -> makeWindowsLookup(); // out of line to workaround javac crash
     };
+
+    private static SymbolLookup makeAixLookup() {
+        throw new InternalError("Default library loading is not yet implemented on AIX"); //$NON-NLS-1$
+    }
 
     private static SymbolLookup makeWindowsLookup() {
         Path system32 = Path.of(System.getenv("SystemRoot"), "System32");

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/SharedUtils.java
@@ -22,6 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.foreign.abi;
 
 import jdk.incubator.foreign.Addressable;
@@ -46,6 +53,9 @@ import jdk.internal.foreign.abi.aarch64.linux.LinuxAArch64Linker;
 import jdk.internal.foreign.abi.aarch64.macos.MacOsAArch64Linker;
 import jdk.internal.foreign.abi.x64.sysv.SysVx64Linker;
 import jdk.internal.foreign.abi.x64.windows.Windowsx64Linker;
+import jdk.internal.foreign.abi.ppc64.sysv.SysVPPC64leLinker;
+import jdk.internal.foreign.abi.ppc64.aix.AixPPC64Linker;
+import jdk.internal.foreign.abi.s390x.sysv.SysVS390xLinker;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -281,6 +291,9 @@ public class SharedUtils {
             case SysV -> SysVx64Linker.getInstance();
             case LinuxAArch64 -> LinuxAArch64Linker.getInstance();
             case MacOsAArch64 -> MacOsAArch64Linker.getInstance();
+            case SysVPPC64le -> SysVPPC64leLinker.getInstance();
+            case SysVS390x -> SysVS390xLinker.getInstance();
+            case AIX -> AixPPC64Linker.getInstance();
         };
     }
 
@@ -486,6 +499,9 @@ public class SharedUtils {
             case SysV -> SysVx64Linker.newVaList(actions, scope);
             case LinuxAArch64 -> LinuxAArch64Linker.newVaList(actions, scope);
             case MacOsAArch64 -> MacOsAArch64Linker.newVaList(actions, scope);
+            case SysVPPC64le -> SysVPPC64leLinker.newVaList(actions, scope);
+            case SysVS390x -> SysVS390xLinker.newVaList(actions, scope);
+            case AIX -> AixPPC64Linker.newVaList(actions, scope);
         };
     }
 
@@ -501,6 +517,9 @@ public class SharedUtils {
             case SysV -> SysVx64Linker.newVaListOfAddress(ma, scope);
             case LinuxAArch64 -> LinuxAArch64Linker.newVaListOfAddress(ma, scope);
             case MacOsAArch64 -> MacOsAArch64Linker.newVaListOfAddress(ma, scope);
+            case SysVPPC64le -> SysVPPC64leLinker.newVaListOfAddress(ma, scope);
+            case SysVS390x -> SysVS390xLinker.newVaListOfAddress(ma, scope);
+            case AIX -> AixPPC64Linker.newVaListOfAddress(ma, scope);
         };
     }
 
@@ -510,6 +529,9 @@ public class SharedUtils {
             case SysV -> SysVx64Linker.emptyVaList();
             case LinuxAArch64 -> LinuxAArch64Linker.emptyVaList();
             case MacOsAArch64 -> MacOsAArch64Linker.emptyVaList();
+            case SysVPPC64le -> SysVPPC64leLinker.emptyVaList();
+            case SysVS390x -> SysVS390xLinker.emptyVaList();
+            case AIX -> AixPPC64Linker.emptyVaList();
         };
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -26,10 +26,9 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
  * ===========================================================================
  */
-
 
 package jdk.internal.foreign.abi.aarch64;
 
@@ -138,14 +137,9 @@ public class CallArranger {
         return handle;
     }
 
+    /* Replace ProgrammableUpcallHandler in OpenJDK with the implementation of ProgrammableUpcallHandler specific to OpenJ9 */
     public static UpcallHandler arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc) {
-        Bindings bindings = getBindings(mt, cDesc, true);
-
-        if (bindings.isInMemoryReturn) {
-            target = SharedUtils.adaptUpcallForIMR(target, true /* drop return, since we don't have bindings for it */);
-        }
-
-        return ProgrammableUpcallHandler.make(C, target, bindings.callingSequence);
+       throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64Linker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64Linker.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.foreign.abi.ppc64.aix;
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.internal.foreign.AbstractCLinker;
+import jdk.internal.foreign.ResourceScopeImpl;
+import jdk.internal.foreign.abi.SharedUtils;
+import jdk.internal.foreign.abi.UpcallStubs;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static jdk.internal.foreign.PlatformLayouts.*;
+
+/**
+ * ABI implementation based on 64-bit PowerPC ELF ABI
+ *
+ * Note: This file is copied from x86/sysv with modification to accommodate the specifics
+ * on AIX/ppc64le and might be updated accordingly in terms of VaList in the future.
+ */
+public class AixPPC64Linker extends AbstractCLinker {
+    private static AixPPC64Linker instance;
+
+    static final long ADDRESS_SIZE = 64; // bits
+
+    private static final MethodHandle MH_unboxVaList;
+    private static final MethodHandle MH_boxVaList;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MH_unboxVaList = lookup.findVirtual(VaList.class, "address",
+                MethodType.methodType(MemoryAddress.class));
+            MH_boxVaList = MethodHandles.insertArguments(lookup.findStatic(AixPPC64Linker.class, "newVaListOfAddress",
+                MethodType.methodType(VaList.class, MemoryAddress.class, ResourceScope.class)), 1, ResourceScope.globalScope());
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static AixPPC64Linker getInstance() {
+        if (instance == null) {
+            instance = new AixPPC64Linker();
+        }
+        return instance;
+    }
+
+    @Override
+    public final MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(function);
+        MethodType llMt = SharedUtils.convertVaListCarriers(type, AixPPC64VaList.CARRIER);
+        MethodHandle handle = CallArranger.arrangeDowncall(llMt, function);
+        if (!type.returnType().equals(MemorySegment.class)) {
+            // not returning segment, just insert a throwing allocator
+            handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
+        }
+        handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
+        return handle;
+    }
+
+    @Override
+    public final MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
+        Objects.requireNonNull(scope);
+        Objects.requireNonNull(target);
+        Objects.requireNonNull(function);
+        target = SharedUtils.boxVaLists(target, MH_boxVaList);
+        return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
+    }
+
+    public static VaList newVaList(Consumer<VaList.Builder> actions, ResourceScope scope) {
+        AixPPC64VaList.Builder builder = AixPPC64VaList.builder(scope);
+        actions.accept(builder);
+        return builder.build();
+    }
+
+    public static VaList newVaListOfAddress(MemoryAddress ma, ResourceScope scope) {
+        return AixPPC64VaList.ofAddress(ma, scope);
+    }
+
+    public static VaList emptyVaList() {
+        return AixPPC64VaList.empty();
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64VaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/aix/AixPPC64VaList.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.foreign.abi.ppc64.aix;
+
+import jdk.incubator.foreign.*;
+import jdk.incubator.foreign.CLinker.VaList;
+import jdk.internal.foreign.ResourceScopeImpl;
+import jdk.internal.foreign.abi.SharedUtils;
+import static jdk.internal.foreign.PlatformLayouts.AIX;
+
+/**
+ * This file serves as a placeholder for VaList on AIX/ppc64le as the code
+ * at Java level is not yet implemented for the moment. Futher analysis on
+ * the struct is required to understand how the struct is laid out in memory
+ * according to the description in the publisized ABI document at
+ * https://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi-1.9.pdf.
+ */
+public non-sealed class AixPPC64VaList implements VaList {
+    public static final Class<?> CARRIER = MemoryAddress.class;
+
+    public static VaList empty() {
+        throw new InternalError("empty() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public int vargAsInt(MemoryLayout layout) {
+        throw new InternalError("vargAsInt() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public long vargAsLong(MemoryLayout layout) {
+        throw new InternalError("vargAsLong() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public double vargAsDouble(MemoryLayout layout) {
+        throw new InternalError("vargAsDouble() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemoryAddress vargAsAddress(MemoryLayout layout) {
+        throw new InternalError("vargAsAddress() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemorySegment vargAsSegment(MemoryLayout layout, SegmentAllocator allocator) {
+        throw new InternalError("vargAsSegment() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemorySegment vargAsSegment(MemoryLayout layout, ResourceScope scope) {
+        throw new InternalError("vargAsSegment() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public void skip(MemoryLayout... layouts) {
+        throw new InternalError("skip() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    public static VaList ofAddress(MemoryAddress ma, ResourceScope scope) {
+        throw new InternalError("ofAddress() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public ResourceScope scope() {
+        throw new InternalError("scope() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public VaList copy() {
+        throw new InternalError("copy() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemoryAddress address() {
+        throw new InternalError("address() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public String toString() {
+        throw new InternalError("toString() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    static AixPPC64VaList.Builder builder(ResourceScope scope) {
+        return new AixPPC64VaList.Builder(scope);
+    }
+
+    public static non-sealed class Builder implements VaList.Builder {
+
+        public Builder(ResourceScope scope) {
+            throw new InternalError("Builder() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromInt(ValueLayout layout, int value) {
+            throw new InternalError("vargFromInt() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromLong(ValueLayout layout, long value) {
+            throw new InternalError("vargFromLong() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromDouble(ValueLayout layout, double value) {
+            throw new InternalError("vargFromDouble() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromAddress(ValueLayout layout, Addressable value) {
+            throw new InternalError("vargFromAddress() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromSegment(GroupLayout layout, MemorySegment value) {
+            throw new InternalError("vargFromSegment() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        public VaList build() {
+            throw new InternalError("build() is not yet implemented"); //$NON-NLS-1$
+        }
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/aix/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/aix/CallArranger.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.foreign.abi.ppc64.aix;
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.internal.foreign.abi.ProgrammableInvoker;
+import jdk.internal.foreign.abi.ProgrammableUpcallHandler;
+import jdk.internal.foreign.abi.UpcallHandler;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+
+/**
+ * For the AIX PPC64 C ABI specifically, this class uses the ProgrammableInvoker API
+ * which is turned into a MethodHandle to invoke the native code.
+ */
+public class CallArranger {
+
+	/* Replace ProgrammableInvoker in OpenJDK with the implementation of ProgrammableInvoker specific to OpenJ9 */
+	public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc) {
+		MethodHandle handle = ProgrammableInvoker.getBoundMethodHandle(mt, cDesc);
+		return handle;
+	}
+
+	/* Replace ProgrammableUpcallHandler in OpenJDK with the implementation of ProgrammableUpcallHandler specific to OpenJ9 */
+	public static UpcallHandler arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc) {
+		throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
+	}
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/sysv/CallArranger.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.foreign.abi.ppc64.sysv;
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.internal.foreign.abi.ProgrammableInvoker;
+import jdk.internal.foreign.abi.ProgrammableUpcallHandler;
+import jdk.internal.foreign.abi.UpcallHandler;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+
+/**
+ * For the SysV ppc64le C ABI specifically, this class uses the ProgrammableInvoker API
+ * which is turned into a MethodHandle to invoke the native code.
+ */
+public class CallArranger {
+
+	/* Replace ProgrammableInvoker in OpenJDK with the implementation of ProgrammableInvoker specific to OpenJ9 */
+	public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc) {
+		MethodHandle handle = ProgrammableInvoker.getBoundMethodHandle(mt, cDesc);
+		return handle;
+	}
+
+	/* Replace ProgrammableUpcallHandler in OpenJDK with the implementation of ProgrammableUpcallHandler specific to OpenJ9 */
+	public static UpcallHandler arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc) {
+		throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
+	}
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/sysv/SysVPPC64leLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/sysv/SysVPPC64leLinker.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.foreign.abi.ppc64.sysv;
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.internal.foreign.AbstractCLinker;
+import jdk.internal.foreign.ResourceScopeImpl;
+import jdk.internal.foreign.abi.SharedUtils;
+import jdk.internal.foreign.abi.UpcallStubs;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * ABI implementation based on System V ABI PPC64LE
+ *
+ * Note: This file is copied from x86/windows with modification to accommodate the specifics
+ * on Linux/ppc64le and might be updated accordingly in terms of VaList in the future.
+ */
+public class SysVPPC64leLinker extends AbstractCLinker {
+    private static SysVPPC64leLinker instance;
+
+    static final long ADDRESS_SIZE = 64; // bits
+
+    private static final MethodHandle MH_unboxVaList;
+    private static final MethodHandle MH_boxVaList;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MH_unboxVaList = lookup.findVirtual(VaList.class, "address",
+                MethodType.methodType(MemoryAddress.class));
+            MH_boxVaList = MethodHandles.insertArguments(lookup.findStatic(SysVPPC64leLinker.class, "newVaListOfAddress",
+                MethodType.methodType(VaList.class, MemoryAddress.class, ResourceScope.class)), 1, ResourceScope.globalScope());
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static SysVPPC64leLinker getInstance() {
+        if (instance == null) {
+            instance = new SysVPPC64leLinker();
+        }
+        return instance;
+    }
+
+    @Override
+    public final MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(function);
+        MethodType llMt = SharedUtils.convertVaListCarriers(type, SysVPPC64leVaList.CARRIER);
+        MethodHandle handle = CallArranger.arrangeDowncall(llMt, function);
+        if (!type.returnType().equals(MemorySegment.class)) {
+            // not returning segment, just insert a throwing allocator
+            handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
+        }
+        handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
+        return handle;
+    }
+
+    @Override
+    public final MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
+        Objects.requireNonNull(scope);
+        Objects.requireNonNull(target);
+        Objects.requireNonNull(function);
+        target = SharedUtils.boxVaLists(target, MH_boxVaList);
+        return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
+    }
+
+    public static VaList newVaList(Consumer<VaList.Builder> actions, ResourceScope scope) {
+        SysVPPC64leVaList.Builder builder = SysVPPC64leVaList.builder(scope);
+        actions.accept(builder);
+        return builder.build();
+    }
+
+    public static VaList newVaListOfAddress(MemoryAddress ma, ResourceScope scope) {
+        return SysVPPC64leVaList.ofAddress(ma, scope);
+    }
+
+    public static VaList emptyVaList() {
+        return SysVPPC64leVaList.empty();
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/sysv/SysVPPC64leVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/sysv/SysVPPC64leVaList.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.foreign.abi.ppc64.sysv;
+
+import jdk.incubator.foreign.*;
+import jdk.incubator.foreign.CLinker.VaList;
+import jdk.internal.foreign.ResourceScopeImpl;
+import jdk.internal.foreign.abi.SharedUtils;
+import static jdk.internal.foreign.PlatformLayouts.SysVPPC64le;
+
+/**
+ * This file serves as a placeholder for VaList on Linux/ppc64le as the code
+ * at Java level is not yet implemented for the moment. Futher analysis on
+ * the struct is required to understand how the struct is laid out in memory
+ * (e.g. the type & size of each field in va_list) and how the registers are
+ * allocated for va_list.
+ */
+public non-sealed class SysVPPC64leVaList implements VaList {
+    public static final Class<?> CARRIER = MemoryAddress.class;
+
+    public static VaList empty() {
+        throw new InternalError("empty() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public int vargAsInt(MemoryLayout layout) {
+        throw new InternalError("vargAsInt() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public long vargAsLong(MemoryLayout layout) {
+        throw new InternalError("vargAsLong() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public double vargAsDouble(MemoryLayout layout) {
+        throw new InternalError("vargAsDouble() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemoryAddress vargAsAddress(MemoryLayout layout) {
+        throw new InternalError("vargAsAddress() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemorySegment vargAsSegment(MemoryLayout layout, SegmentAllocator allocator) {
+        throw new InternalError("vargAsSegment() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemorySegment vargAsSegment(MemoryLayout layout, ResourceScope scope) {
+        throw new InternalError("vargAsSegment() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public void skip(MemoryLayout... layouts) {
+        throw new InternalError("skip() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    public static VaList ofAddress(MemoryAddress ma, ResourceScope scope) {
+        throw new InternalError("ofAddress() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public ResourceScope scope() {
+        throw new InternalError("scope() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public VaList copy() {
+        throw new InternalError("copy() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemoryAddress address() {
+        throw new InternalError("address() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public String toString() {
+        throw new InternalError("toString() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    static SysVPPC64leVaList.Builder builder(ResourceScope scope) {
+        return new SysVPPC64leVaList.Builder(scope);
+    }
+
+    public static non-sealed class Builder implements VaList.Builder {
+
+        public Builder(ResourceScope scope) {
+            throw new InternalError("Builder() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromInt(ValueLayout layout, int value) {
+            throw new InternalError("vargFromInt() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromLong(ValueLayout layout, long value) {
+            throw new InternalError("vargFromLong() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromDouble(ValueLayout layout, double value) {
+            throw new InternalError("vargFromDouble() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromAddress(ValueLayout layout, Addressable value) {
+            throw new InternalError("vargFromAddress() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromSegment(GroupLayout layout, MemorySegment value) {
+            throw new InternalError("vargFromSegment() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        public VaList build() {
+            throw new InternalError("build() is not yet implemented"); //$NON-NLS-1$
+        }
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/s390x/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/s390x/sysv/CallArranger.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.foreign.abi.s390x.sysv;
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.internal.foreign.abi.ProgrammableInvoker;
+import jdk.internal.foreign.abi.ProgrammableUpcallHandler;
+import jdk.internal.foreign.abi.UpcallHandler;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+
+/**
+ * For the SysV s390 C ABI specifically, this class uses the ProgrammableInvoker API
+ * which is turned into a MethodHandle to invoke the native code.
+ */
+public class CallArranger {
+	/* Replace ProgrammableInvoker in OpenJDK with the implementation of ProgrammableInvoker specific to OpenJ9 */
+	public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc) {
+		MethodHandle handle = ProgrammableInvoker.getBoundMethodHandle(mt, cDesc);
+		return handle;
+	}
+
+	/* Replace ProgrammableUpcallHandler in OpenJDK with the implementation of ProgrammableUpcallHandler specific to OpenJ9 */
+	public static UpcallHandler arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc) {
+		throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
+	}
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/s390x/sysv/SysVS390xLinker.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/s390x/sysv/SysVS390xLinker.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.foreign.abi.s390x.sysv;
+
+import jdk.incubator.foreign.FunctionDescriptor;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.MemorySegment;
+import jdk.incubator.foreign.ResourceScope;
+import jdk.internal.foreign.AbstractCLinker;
+import jdk.internal.foreign.ResourceScopeImpl;
+import jdk.internal.foreign.abi.SharedUtils;
+import jdk.internal.foreign.abi.UpcallStubs;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * ABI implementation based on System V ABI s390x
+ *
+ * Note: This file is copied from x86/sysv with modification to accommodate the specifics
+ * on Linux/s390x and might be updated accordingly in terms of VaList in the future.
+ */
+public class SysVS390xLinker extends AbstractCLinker {
+    private static SysVS390xLinker instance;
+
+    static final long ADDRESS_SIZE = 64; // bits
+
+    private static final MethodHandle MH_unboxVaList;
+    private static final MethodHandle MH_boxVaList;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            MH_unboxVaList = lookup.findVirtual(VaList.class, "address",
+                MethodType.methodType(MemoryAddress.class));
+            MH_boxVaList = MethodHandles.insertArguments(lookup.findStatic(SysVS390xLinker.class, "newVaListOfAddress",
+                MethodType.methodType(VaList.class, MemoryAddress.class, ResourceScope.class)), 1, ResourceScope.globalScope());
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    public static SysVS390xLinker getInstance() {
+        if (instance == null) {
+            instance = new SysVS390xLinker();
+        }
+        return instance;
+    }
+
+    @Override
+    public final MethodHandle downcallHandle(MethodType type, FunctionDescriptor function) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(function);
+        MethodType llMt = SharedUtils.convertVaListCarriers(type, SysVS390xVaList.CARRIER);
+        MethodHandle handle = CallArranger.arrangeDowncall(llMt, function);
+        if (!type.returnType().equals(MemorySegment.class)) {
+            // not returning segment, just insert a throwing allocator
+            handle = MethodHandles.insertArguments(handle, 1, SharedUtils.THROWING_ALLOCATOR);
+        }
+        handle = SharedUtils.unboxVaLists(type, handle, MH_unboxVaList);
+        return handle;
+    }
+
+    @Override
+    public final MemoryAddress upcallStub(MethodHandle target, FunctionDescriptor function, ResourceScope scope) {
+        Objects.requireNonNull(scope);
+        Objects.requireNonNull(target);
+        Objects.requireNonNull(function);
+        target = SharedUtils.boxVaLists(target, MH_boxVaList);
+        return UpcallStubs.upcallAddress(CallArranger.arrangeUpcall(target, target.type(), function), (ResourceScopeImpl) scope);
+    }
+
+    public static VaList newVaList(Consumer<VaList.Builder> actions, ResourceScope scope) {
+        SysVS390xVaList.Builder builder = SysVS390xVaList.builder(scope);
+        actions.accept(builder);
+        return builder.build();
+    }
+
+    public static VaList newVaListOfAddress(MemoryAddress ma, ResourceScope scope) {
+        return SysVS390xVaList.ofAddress(ma, scope);
+    }
+
+    public static VaList emptyVaList() {
+        return SysVS390xVaList.empty();
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/s390x/sysv/SysVS390xVaList.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/s390x/sysv/SysVS390xVaList.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
+package jdk.internal.foreign.abi.s390x.sysv;
+
+import jdk.incubator.foreign.*;
+import jdk.incubator.foreign.CLinker.VaList;
+import jdk.internal.foreign.ResourceScopeImpl;
+import jdk.internal.foreign.abi.SharedUtils;
+import static jdk.internal.foreign.PlatformLayouts.SysVS390x;
+
+/**
+ * This file serves as a placeholder for VaList on Linux/s390x as the code
+ * at Java level is not yet implemented for the moment. Futher analysis on
+ * the struct is required to understand how the struct is laid out in memory
+ * (e.g. the type & size of each field in va_list) and how the registers are
+ * allocated for va_list according to the description in the publisized ABI
+ * document at https://refspecs.linuxfoundation.org/ELF/zSeries/lzsabi0_zSeries.pdf.
+ */
+public non-sealed class SysVS390xVaList implements VaList {
+    public static final Class<?> CARRIER = MemoryAddress.class;
+
+    public static VaList empty() {
+        throw new InternalError("empty() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public int vargAsInt(MemoryLayout layout) {
+        throw new InternalError("vargAsInt() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public long vargAsLong(MemoryLayout layout) {
+        throw new InternalError("vargAsLong() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public double vargAsDouble(MemoryLayout layout) {
+        throw new InternalError("vargAsDouble() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemoryAddress vargAsAddress(MemoryLayout layout) {
+        throw new InternalError("vargAsAddress() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemorySegment vargAsSegment(MemoryLayout layout, SegmentAllocator allocator) {
+        throw new InternalError("vargAsSegment() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemorySegment vargAsSegment(MemoryLayout layout, ResourceScope scope) {
+        throw new InternalError("vargAsSegment() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public void skip(MemoryLayout... layouts) {
+        throw new InternalError("skip() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    public static VaList ofAddress(MemoryAddress ma, ResourceScope scope) {
+        throw new InternalError("ofAddress() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public ResourceScope scope() {
+        throw new InternalError("scope() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public VaList copy() {
+        throw new InternalError("copy() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public MemoryAddress address() {
+        throw new InternalError("address() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    @Override
+    public String toString() {
+        throw new InternalError("toString() is not yet implemented"); //$NON-NLS-1$
+    }
+
+    static SysVS390xVaList.Builder builder(ResourceScope scope) {
+        return new SysVS390xVaList.Builder(scope);
+    }
+
+    public static non-sealed class Builder implements VaList.Builder {
+
+        public Builder(ResourceScope scope) {
+            throw new InternalError("Builder() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromInt(ValueLayout layout, int value) {
+            throw new InternalError("vargFromInt() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromLong(ValueLayout layout, long value) {
+            throw new InternalError("vargFromLong() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromDouble(ValueLayout layout, double value) {
+            throw new InternalError("vargFromDouble() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromAddress(ValueLayout layout, Addressable value) {
+            throw new InternalError("vargFromAddress() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        @Override
+        public Builder vargFromSegment(GroupLayout layout, MemorySegment value) {
+            throw new InternalError("vargFromSegment() is not yet implemented"); //$NON-NLS-1$
+        }
+
+        public VaList build() {
+            throw new InternalError("build() is not yet implemented"); //$NON-NLS-1$
+        }
+    }
+}

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -26,7 +26,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
  * ===========================================================================
  */
 
@@ -134,14 +134,9 @@ public class CallArranger {
         return handle;
     }
 
+    /* Replace ProgrammableUpcallHandler in OpenJDK with the implementation of ProgrammableUpcallHandler specific to OpenJ9 */
     public static UpcallHandler arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc) {
-        Bindings bindings = getBindings(mt, cDesc, true);
-
-        if (bindings.isInMemoryReturn) {
-            target = SharedUtils.adaptUpcallForIMR(target, true /* drop return, since we don't have bindings for it */);
-        }
-
-        return ProgrammableUpcallHandler.make(CSysV, target, bindings.callingSequence);
+       throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
  * ===========================================================================
  */
 
@@ -135,14 +135,9 @@ public class CallArranger {
         return handle;
     }
 
+    /* Replace ProgrammableUpcallHandler in OpenJDK with the implementation of ProgrammableUpcallHandler specific to OpenJ9 */
     public static UpcallHandler arrangeUpcall(MethodHandle target, MethodType mt, FunctionDescriptor cDesc) {
-        Bindings bindings = getBindings(mt, cDesc, true);
-
-        if (bindings.isInMemoryReturn) {
-            target = SharedUtils.adaptUpcallForIMR(target, false /* need the return value as well */);
-        }
-
-        return ProgrammableUpcallHandler.make(CWindows, target, bindings.callingSequence);
+        throw new InternalError("arrangeUpcall is not yet implemented"); //$NON-NLS-1$
     }
 
     private static boolean isInMemoryReturn(Optional<MemoryLayout> returnLayout) {


### PR DESCRIPTION
The changes aim to enable the CLinker downcall handle to support
primitives and struct on AIX/ppc64, Linux/ppc64le and Linux/s390x
by invoking the code in ProgrammableInvoker implemented in OpenJ9.

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>