### PR TITLE
Add support for building for AArch64 macOS

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -62,7 +62,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
     ],
     [
       case "$OPENJ9_PLATFORM_CODE" in
-        ap64|oa64|wa64|xa64|xl64|xr64|xz64)
+        ap64|oa64|or64|wa64|xa64|xl64|xr64|xz64)
           if test "x$COMPILE_TYPE" != xcross ; then
             with_cmake=cmake
           else
@@ -425,16 +425,16 @@ AC_DEFUN([OPENJ9_PLATFORM_SETUP],
   fi
 
   if test "x$OPENJ9_CPU" = xx86-64 ; then
-    if test "x$OPENJ9_BUILD_OS" = xlinux ; then
+    if test "x$OPENJDK_BUILD_OS" = xlinux ; then
       OPENJ9_PLATFORM_CODE=xa64
-    elif test "x$OPENJ9_BUILD_OS" = xwindows ; then
+    elif test "x$OPENJDK_BUILD_OS" = xwindows ; then
       OPENJ9_PLATFORM_CODE=wa64
       OPENJ9_BUILD_OS=win
-    elif test "x$OPENJ9_BUILD_OS" = xmacosx ; then
+    elif test "x$OPENJDK_BUILD_OS" = xmacosx ; then
       OPENJ9_PLATFORM_CODE=oa64
       OPENJ9_BUILD_OS=osx
     else
-      AC_MSG_ERROR([Unsupported OpenJ9 platform ${OPENJ9_BUILD_OS}!])
+      AC_MSG_ERROR([Unsupported OpenJ9 platform ${OPENJDK_BUILD_OS}!])
     fi
   elif test "x$OPENJ9_CPU" = xppc-64_le ; then
     OPENJ9_PLATFORM_CODE=xl64
@@ -455,9 +455,16 @@ AC_DEFUN([OPENJ9_PLATFORM_SETUP],
     OPENJ9_BUILD_MODE_ARCH=arm_linaro
     OPENJ9_LIBS_SUBDIR=default
   elif test "x$OPENJ9_CPU" = xaarch64 ; then
-    OPENJ9_PLATFORM_CODE=xr64
-    if test "x$COMPILE_TYPE" = xcross ; then
-      OPENJ9_BUILD_MODE_ARCH="${OPENJ9_BUILD_MODE_ARCH}_cross"
+    if test "x$OPENJDK_BUILD_OS" = xlinux ; then
+      OPENJ9_PLATFORM_CODE=xr64
+      if test "x$COMPILE_TYPE" = xcross ; then
+        OPENJ9_BUILD_MODE_ARCH="${OPENJ9_BUILD_MODE_ARCH}_cross"
+      fi
+    elif test "x$OPENJDK_BUILD_OS" = xmacosx ; then
+      OPENJ9_PLATFORM_CODE=or64
+      OPENJ9_BUILD_OS=osx
+    else
+      AC_MSG_ERROR([Unsupported OpenJ9 platform ${OPENJDK_BUILD_OS}!])
     fi
   else
     AC_MSG_ERROR([Unsupported OpenJ9 cpu ${OPENJ9_CPU}!])

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -120,7 +120,7 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
   export MSVC_VERSION := @TOOLCHAIN_VERSION@
 endif
 
-ifeq ($(OPENJDK_BUILD_OS), macosx)
+ifeq ($(OPENJDK_TARGET_OS), macosx)
   # MACOSX_DEPLOYMENT_TARGET acts similar to -mmacosx-version-min=version
   # compiler option. If both the compiler option is specified and the
   # environment variable is set, then the compiler option will take
@@ -130,8 +130,10 @@ ifeq ($(OPENJDK_BUILD_OS), macosx)
   # is not applied.
   export MACOSX_DEPLOYMENT_TARGET := @MACOSX_VERSION_MIN@
 
-  # Set page zero size to 4KB for mapping memory below 4GB.
-  LDFLAGS_JDKEXE += -pagezero_size 0x1000
+  ifneq ($(OPENJDK_TARGET_CPU), aarch64)
+    # Set page zero size to 4KB for mapping memory below 4GB.
+    LDFLAGS_JDKEXE += -pagezero_size 0x1000
+  endif
 endif
 
 # Usage: $(call CodesignFile, files ...)

--- a/closed/custom/modules/java.base/Copy.gmk
+++ b/closed/custom/modules/java.base/Copy.gmk
@@ -50,8 +50,9 @@ $(call openj9_copy_files_and_debuginfos, \
 		$(OPENJ9_VM_BUILD_DIR)/ \
 		$(addprefix $(LIB_DST_DIR), / /j9vm/ /server/)))
 
-# CPU targets without JIT support.
-NO_JIT_CPUS := riscv64
+# Target platforms without JIT support.
+NO_JIT_PLATFORMS := linux_riscv64 macosx_aarch64
+TARGET_PLATFORM := $(OPENJDK_TARGET_OS)_$(OPENJDK_TARGET_CPU)
 
 $(call openj9_copy_shlibs, \
 	j9dmp29 \
@@ -60,7 +61,7 @@ $(call openj9_copy_shlibs, \
 	j9gcchk29 \
 	$(if $(filter static,$(OMR_MIXED_REFERENCES_MODE)),j9gcchk_full29) \
 	j9hookable29 \
-	$(if $(filter $(NO_JIT_CPUS),$(OPENJDK_TARGET_CPU)),,j9jit29) \
+	$(if $(filter $(NO_JIT_PLATFORMS),$(TARGET_PLATFORM)),,j9jit29) \
 	j9jnichk29 \
 	j9jvmti29 \
 	j9prt29 \
@@ -173,10 +174,10 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   TARGETS += $(LIBCRYPTO_TARGET_LIB)
   $(LIBCRYPTO_TARGET_LIB) : $(LIBCRYPTO_PATH)
 	$(call install-file)
-  ifeq ($(OPENJDK_BUILD_OS), macosx)
+  ifeq ($(OPENJDK_TARGET_OS), macosx)
     # update @rpath of the crypto library as the default is /usr/local/lib/
 	install_name_tool -id "@rpath/$(@F)" $@
-  else ifeq ($(OPENJDK_BUILD_OS), windows)
+  else ifeq ($(OPENJDK_TARGET_OS), windows)
 	$(CHMOD) a+rx $@
   endif
 	$(call CodesignFile,"$@")

--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -35,7 +35,8 @@ include $(SPEC)
 #     For Linux x64, it is linux-x86_64
 #     For Windows x64, it is VC-WIN64A
 #     For Windows x32, it is VC-WIN32
-#     For Mac OSX, it is darwin64-x86_64-cc
+#     For Mac OSX x64, it is darwin64-x86_64-cc
+#     For Mac OSX aarch64, it is darwin64-arm64-cc
 build_openssl :
 ifeq ($(BUILD_OPENSSL), yes)
 	$(ECHO) Compiling OpenSSL in $(OPENSSL_DIR)
@@ -50,7 +51,11 @@ ifeq ($(BUILD_OPENSSL), yes)
 	($(CD) $(OPENSSL_DIR) && ./config shared && $(MAKE))
     endif
   else ifeq ($(OPENJDK_TARGET_OS), macosx)
-	($(CD) $(OPENSSL_DIR) && ./Configure darwin64-x86_64-cc shared  && $(MAKE))
+    ifeq ($(OPENJDK_TARGET_CPU), x86_64)
+	($(CD) $(OPENSSL_DIR) && ./Configure darwin64-x86_64-cc shared && $(MAKE))
+    else
+	($(CD) $(OPENSSL_DIR) && ./Configure darwin64-arm64-cc shared && $(MAKE))
+    endif
   else ifeq ($(OPENJDK_TARGET_OS), windows)
     ifeq ($(OPENJDK_TARGET_CPU), x86_64)
 	($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN64A shared && $(MAKE))


### PR DESCRIPTION
This commit adds the support for building for AArch64 macOS.

- Stop adding the "-pagezero_size" linker option
- Stop copying the JIT compiler shared library

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>