### PR TITLE
(0.29) Revert "Replace ProgrammableInvoker (downcall) on X86_64 & Aarch64"

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -163,7 +163,6 @@ $(foreach file, \
 		bcuwhite \
 		bcvrelationships \
 		bcvwhite \
-		clinkerffitests \
 		gptest \
 		hooktests \
 		j9aixbaddep \

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/aarch64/CallArranger.java
@@ -23,14 +23,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
- * ===========================================================================
- */
-
-
 package jdk.internal.foreign.abi.aarch64;
 
 import jdk.incubator.foreign.FunctionDescriptor;
@@ -132,9 +124,15 @@ public class CallArranger {
         return new Bindings(csb.build(), returnInMemory);
     }
 
-    /* Replace ProgrammableInvoker in OpenJDK with the implementation of ProgrammableInvoker specific to OpenJ9 */
     public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc) {
-        MethodHandle handle = ProgrammableInvoker.getBoundMethodHandle(mt, cDesc);
+        Bindings bindings = getBindings(mt, cDesc, false);
+
+        MethodHandle handle = new ProgrammableInvoker(C, bindings.callingSequence).getBoundMethodHandle();
+
+        if (bindings.isInMemoryReturn) {
+            handle = SharedUtils.adaptDowncallForIMR(handle, cDesc);
+        }
+
         return handle;
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/sysv/CallArranger.java
@@ -23,13 +23,6 @@
  *  questions.
  *
  */
-
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
- * ===========================================================================
- */
-
 package jdk.internal.foreign.abi.x64.sysv;
 
 import jdk.incubator.foreign.FunctionDescriptor;
@@ -128,9 +121,16 @@ public class CallArranger {
         return new Bindings(csb.build(), returnInMemory, argCalc.storageCalculator.nVectorReg);
     }
 
-    /* Replace ProgrammableInvoker in OpenJDK with the implementation of ProgrammableInvoker specific to OpenJ9 */
     public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc) {
-        MethodHandle handle = ProgrammableInvoker.getBoundMethodHandle(mt, cDesc);
+        Bindings bindings = getBindings(mt, cDesc, false);
+
+        MethodHandle handle = new ProgrammableInvoker(CSysV, bindings.callingSequence).getBoundMethodHandle();
+        handle = MethodHandles.insertArguments(handle, handle.type().parameterCount() - 1, bindings.nVectorArgs);
+
+        if (bindings.isInMemoryReturn) {
+            handle = SharedUtils.adaptDowncallForIMR(handle, cDesc);
+        }
+
         return handle;
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/x64/windows/CallArranger.java
@@ -22,13 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
- * ===========================================================================
- */
-
 package jdk.internal.foreign.abi.x64.windows;
 
 import jdk.incubator.foreign.FunctionDescriptor;
@@ -129,9 +122,15 @@ public class CallArranger {
         return new Bindings(csb.csb.build(), returnInMemory);
     }
 
-    /* Replace ProgrammableInvoker in OpenJDK with the implementation of ProgrammableInvoker specific to OpenJ9 */
     public static MethodHandle arrangeDowncall(MethodType mt, FunctionDescriptor cDesc) {
-        MethodHandle handle = ProgrammableInvoker.getBoundMethodHandle(mt, cDesc);
+        Bindings bindings = getBindings(mt, cDesc, false);
+
+        MethodHandle handle = new ProgrammableInvoker(CWindows, bindings.callingSequence).getBoundMethodHandle();
+
+        if (bindings.isInMemoryReturn) {
+            handle = SharedUtils.adaptDowncallForIMR(handle, cDesc);
+        }
+
         return handle;
     }
 


### PR DESCRIPTION
This reverts commit e684da3dd0ddafd04f5be977846f7c24084bc97e, PR https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/36 which was accidentally added to the 0.29 release branch.