### PR TITLE
zOS: Add 31/64-bit interoperability staging

### DIFF
--- a/closed/custom/modules/java.base/Copy.gmk
+++ b/closed/custom/modules/java.base/Copy.gmk
@@ -30,6 +30,28 @@ $(call openj9_copy_files,, \
 	$(OPENJ9_VM_BUILD_DIR)/include/jvmti.h \
 	$(INCLUDE_TARGET_DIR)/jvmti.h)
 
+ifeq (zos,$(OPENJDK_TARGET_OS))
+$(call openj9_copy_files,, \
+	$(OPENJ9_TOPDIR)/runtime/include/jni_convert.h \
+	$(INCLUDE_TARGET_DIR)/jni_convert.h)
+
+# Customized z/OS 31/64-bit interoperability JNI header files.
+# These files are generated as part of an OpenJ9 build.
+INCLUDE31_SOURCE_DIR := $(OPENJ9_VM_BUILD_DIR)/include31
+INCLUDE31_TARGET_DIR := $(INCLUDE_TARGET_DIR)/jni31
+$(call openj9_copy_files,, \
+	$(INCLUDE31_SOURCE_DIR)/jni.h \
+	$(INCLUDE31_TARGET_DIR)/jni.h)
+
+$(call openj9_copy_files,, \
+	$(INCLUDE31_SOURCE_DIR)/jni_convert.h \
+	$(INCLUDE31_TARGET_DIR)/jni_convert.h)
+
+$(call openj9_copy_files,, \
+	$(INCLUDE31_SOURCE_DIR)/jniport.h \
+	$(INCLUDE31_TARGET_DIR)/jniport.h)
+endif # zos
+
 # jitserver
 
 ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
@@ -77,14 +99,34 @@ $(call openj9_copy_shlibs, \
 	omrsig \
 	)
 
-ifeq ($(OPENJDK_TARGET_OS), zos)
+ifeq (zos,$(OPENJDK_TARGET_OS))
 
 $(call openj9_copy_files_and_debuginfos, \
 	$(addsuffix /$(call SHARED_LIBRARY,j9a2e), \
 		$(OPENJ9_VM_BUILD_DIR) \
 		$(LIB_DST_DIR)))
 
-endif
+$(call openj9_copy_files,, \
+	$(addsuffix libjsig.x, \
+		$(OPENJ9_VM_BUILD_DIR)/lib/ \
+		$(addprefix $(LIB_DST_DIR), / /j9vm/ /server/)))
+
+$(call openj9_copy_files,, \
+	$(addsuffix libjvm.x, \
+		$(OPENJ9_VM_BUILD_DIR)/lib/redirector/ \
+		$(addprefix $(LIB_DST_DIR), /j9vm/ /server/)))
+
+# 31/64-bit interoperability shim library and side deck files.
+$(call openj9_copy_files_and_debuginfos, \
+	$(addsuffix $(call SHARED_LIBRARY,jvm31), \
+		$(OPENJ9_VM_BUILD_DIR)/ \
+		$(addprefix $(LIB_DST_DIR), /j9vm/ /server/)))
+
+$(call openj9_copy_files,, \
+	$(addsuffix libjvm31.x, \
+		$(OPENJ9_VM_BUILD_DIR)/lib/ \
+		$(addprefix $(LIB_DST_DIR), /j9vm/ /server/)))
+endif # zos
 
 # static libraries that are needed on some platforms
 

--- a/closed/custom/modules/java.base/Copy.gmk
+++ b/closed/custom/modules/java.base/Copy.gmk
@@ -188,18 +188,18 @@ endif # OPENJ9_ENABLE_DDR
 # Optionally copy OpenSSL Crypto Library
 # To bundle first search for openssl 1.1.x library, if not found, search for 1.0.x
 ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
-  ifeq ($(OPENJDK_TARGET_OS), linux)
+  ifeq (linux,$(OPENJDK_TARGET_OS))
     LIBCRYPTO_NAMES := libcrypto.so.1.1 libcrypto.so.1.0.0
-  else ifeq ($(OPENJDK_TARGET_OS), macosx)
+  else ifeq (macosx,$(OPENJDK_TARGET_OS))
     LIBCRYPTO_NAMES := libcrypto.1.1.dylib libcrypto.1.0.0.dylib
-  else ifeq ($(OPENJDK_TARGET_OS), windows)
+  else ifeq (windows,$(OPENJDK_TARGET_OS))
     ifeq ($(OPENJDK_TARGET_CPU_BITS), 64)
       LIBCRYPTO_NAMES := libcrypto-1_1-x64.dll
     else
       LIBCRYPTO_NAMES := libcrypto-1_1.dll
     endif
     LIBCRYPTO_NAMES += libeay32.dll
-  else ifeq ($(OPENJDK_TARGET_OS), aix)
+  else ifeq (aix,$(OPENJDK_TARGET_OS))
     # OpenSSL 1.1.1 on AIX has switched to use archive library files (natural way)
     # instead of 'libcrypto.so' files.
     # See https://github.com/openssl/openssl/pull/6487.
@@ -216,16 +216,16 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   TARGETS += $(LIBCRYPTO_TARGET_LIB)
   $(LIBCRYPTO_TARGET_LIB) : $(LIBCRYPTO_PATH)
 	$(call install-file)
-  ifeq ($(OPENJDK_TARGET_OS), macosx)
+  ifeq (macosx,$(OPENJDK_TARGET_OS))
     # update @rpath of the crypto library as the default is /usr/local/lib/
 	install_name_tool -id "@rpath/$(@F)" $@
-  else ifeq ($(OPENJDK_TARGET_OS), windows)
+  else ifeq (windows,$(OPENJDK_TARGET_OS))
 	$(CHMOD) a+rx $@
   endif
 	$(call CodesignFile,"$@")
 
   ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
-    ifeq ($(OPENJDK_TARGET_OS), linux)
+    ifeq (linux,$(OPENJDK_TARGET_OS))
       LIBSSL_NAMES := libssl.so.1.1 libssl.so.1.0.0
       LIBSSL_PATH := $(firstword $(wildcard $(addprefix $(OPENSSL_BUNDLE_LIB_PATH)/, $(LIBSSL_NAMES))))
 


### PR DESCRIPTION
Cherry-pick of: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/378

- Copy the customized JNI header files to include/jni31 directory for java.base
- Copy the libjvm31.so library and libjvm31.x sidedeck to server / j9vm.

Signed-off-by: Joran Siu <joransiu@ca.ibm.com>