### PR TITLE
Fix crash in native crypto on concurrent Cipher object use with GCM

### DIFF
--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2020 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
  * ===========================================================================
  */
 
@@ -182,7 +182,10 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
 
         mode = (decrypting) ? 0 : 1;
 
-        int ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length);
+        int ret;
+        synchronized (this) {
+            ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length);
+        }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");
         }
@@ -196,7 +199,10 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
      */
     void reset() {
         System.arraycopy(iv, 0, r, 0, blockSize);
-        int ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length);
+        int ret;
+        synchronized (this) {
+            ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length);
+        }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");
         }
@@ -217,7 +223,10 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
      */
     void restore() {
         System.arraycopy(rSave, 0, r, 0, blockSize);
-        int ret = nativeCrypto.CBCInit(nativeContext, mode, r, r.length, key, key.length);
+        int ret;
+        synchronized (this) {
+            ret = nativeCrypto.CBCInit(nativeContext, mode, r, r.length, key, key.length);
+        }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");
         }
@@ -251,8 +260,11 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
             throw new ProviderException("Internal error in input buffering");
         }
 
-        int ret = nativeCrypto.CBCUpdate(nativeContext, plain, plainOffset,
-                                          plainLen, cipher, cipherOffset);
+        int ret;
+        synchronized (this) {
+            ret = nativeCrypto.CBCUpdate(nativeContext, plain, plainOffset,
+                                            plainLen, cipher, cipherOffset);
+        }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");
         }
@@ -309,14 +321,16 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
     int encryptFinal(byte[] plain, int plainOffset, int plainLen,
                      byte[] cipher, int cipherOffset) {
 
-        int ret = -1;
+        int ret;
 
-        if(plain == cipher) {
-            ret = nativeCrypto.CBCFinalEncrypt(nativeContext, plain.clone(),
-                                               plainOffset, plainLen, cipher, cipherOffset);
-        } else {
-            ret = nativeCrypto.CBCFinalEncrypt(nativeContext, plain, plainOffset,
-                                                plainLen, cipher, cipherOffset);
+        synchronized (this) {
+            if (plain == cipher) {
+                ret = nativeCrypto.CBCFinalEncrypt(nativeContext, plain.clone(),
+                                                plainOffset, plainLen, cipher, cipherOffset);
+            } else {
+                ret = nativeCrypto.CBCFinalEncrypt(nativeContext, plain, plainOffset,
+                                                    plainLen, cipher, cipherOffset);
+            }
         }
 
         if (ret == -1) {


### PR DESCRIPTION
This is an adaptation of PR [openj9-openjdk-jdk16#66](https://github.com/ibmruntimes/openj9-openjdk-jdk16/pull/66). 
I added synchronization to any usage of the following variables in the NativeGaloisCounterMode class: `tagLenBytes`, `ibuffer`, `key`, `iv`, and `aadBuffer`.

Signed-off-by: Zainab Fatmi <zainab@ibm.com>