### PR TITLE
Update jdk.test.lib.Platform to work with J9

### DIFF
--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.test.lib;
 
 import java.io.FileNotFoundException;
@@ -54,12 +60,16 @@ public class Platform {
                 PrivilegedAction<String>) () -> System.getProperty(key));
     }
 
+    private static boolean isJ9() {
+        return vmName.contains("OpenJ9") || vmName.contains("IBM");
+    }
+
     public static boolean isClient() {
         return vmName.endsWith(" Client VM");
     }
 
     public static boolean isServer() {
-        return vmName.endsWith(" Server VM");
+        return isJ9() || vmName.endsWith(" Server VM");
     }
 
     public static boolean isZero() {
@@ -377,7 +387,7 @@ public class Platform {
 
     public static boolean isDefaultCDSArchiveSupported() {
         return (is64bit()  &&
-                isServer() &&
+                isServer() && !isJ9() &&
                 (isLinux()   ||
                  isOSX()     ||
                  isWindows()) &&


### PR DESCRIPTION
`isServer()` updated to return `true` if `java.vm.name` contains `OpenJ9` or `IBM`.

`isDefaultCDSArchiveSupported()` updated to return `false` if `java.vm.name` contains
`OpenJ9` or `IBM` since J9 does not support the default CDS archive.

This is an updated fix for eclipse-openj9/openj9#14079.

Related: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/390

Backport: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/391

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>