### PR TITLE
Add support for AArch64 macOS in closed/openssl.gmk

### DIFF
--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -58,6 +58,8 @@ else ifeq ($(OPENJDK_TARGET_OS), linux)
 else ifeq ($(OPENJDK_TARGET_OS), macosx)
   ifneq (,$(filter arm64 x86_64, $(OPENJDK_TARGET_CPU)))
     OPENSSL_TARGET := darwin64-$(OPENJDK_TARGET_CPU)-cc
+  else ifeq ($(OPENJDK_TARGET_CPU), aarch64)
+    OPENSSL_TARGET := darwin64-arm64-cc
   endif
 else ifeq ($(OPENJDK_TARGET_OS), windows)
   ifeq ($(OPENJDK_TARGET_CPU), x86_64)


### PR DESCRIPTION
This commit adds support for AArch64 macOS in closed/openssl.gmk.

Signed-off-by: KONNO Kazuhiro <konno@jp.ibm.com>