### PR TITLE
CMake: Don't use separate cross compile spec

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -338,7 +338,7 @@ run-preprocessors-j9 : \
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 
   CMAKE_ARGS := \
-	-C $(OPENJ9_TOPDIR)/runtime/cmake/caches/$(OPENJ9_BUILDSPEC).cmake \
+	-C $(OPENJ9_TOPDIR)/runtime/cmake/caches/$(patsubst %_cross,%,$(OPENJ9_BUILDSPEC)).cmake \
 	-DCMAKE_TOOLCHAIN_FILE="$(OUTPUTDIR)/toolchain.cmake" \
 	-DBOOT_JDK="$(BOOT_JDK)" \
 	-DBUILD_ID=$(BUILD_ID) \


### PR DESCRIPTION
see ibmruntimes/openj9-openjdk-jdk#386

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>