### PR TITLE
Add IncludeIfUnsure for $(SUPPORT_OUTPUTDIR)/overlay

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -85,7 +85,8 @@ $(J9JCL_SOURCES_DONEFILE) : \
 		JAVA_HOME=$(BOOT_JDK) \
 		preprocessor
 	@$(ECHO) Generating J9JCL sources
-	$(call RunJPP, JAVA$(VERSION_FEATURE), $(SUPPORT_OUTPUTDIR)/overlay)
+	$(call RunJPP, JAVA$(VERSION_FEATURE), $(SUPPORT_OUTPUTDIR)/overlay) \
+		$(IncludeIfUnsure)
 	$(call RunJPP, JAVA$(VERSION_FEATURE), $(TOPDIR)/closed) \
 		$(IncludeIfUnsure)
 	$(call RunJPP, JAVA$(VERSION_FEATURE), $(OPENJ9_TOPDIR)/jcl)


### PR DESCRIPTION
This matches `$(TOPDIR)/closed`.

Cherry-pick https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/511

Signed-off-by: Jason Feng <fengj@ca.ibm.com>