### PR TITLE
Adopt configuration GENERIC to generate DDR_VM sources

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -92,7 +92,7 @@ $(J9JCL_SOURCES_DONEFILE) : \
 	$(call RunJPP, JAVA$(VERSION_FEATURE), $(OPENJ9_TOPDIR)/jcl)
   ifeq (true,$(OPENJ9_ENABLE_DDR))
 	@$(ECHO) Generating DDR_VM sources
-	$(call RunJPP, DDR_VM, $(OPENJ9_TOPDIR)/debugtools/DDR_VM, /openj9.dtfj/share/classes) \
+	$(call RunJPP, GENERIC, $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src, /openj9.dtfj/share/classes) \
 		$(IncludeIfUnsure) \
 		-macro:define JAVA_SPEC_VERSION=$(VERSION_FEATURE)
   endif # OPENJ9_ENABLE_DDR


### PR DESCRIPTION
Replaced configuration `DDR_VM` with `GENERIC`.

Cherry-pick https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/436
Depends on https://github.com/eclipse-openj9/openj9/pull/14982

Signed-off-by: Jason Feng <fengj@ca.ibm.com>