### PR TITLE
Fix warnings in openj9 java code patches

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -366,15 +366,12 @@ public class ObjectInputStream
      * read* requests
      */
 
-    /* ClassByNameCache Entry for caching class.forName results upon enableClassCaching */
-    private static final ClassByNameCache classByNameCache;
-    private static final boolean isClassCachingEnabled;
-    static {
-        isClassCachingEnabled =
+    @SuppressWarnings("removal")
+    private static final boolean isClassCachingEnabled =
             AccessController.doPrivileged(new GetClassCachingSettingAction());
-        classByNameCache = (isClassCachingEnabled ? new ClassByNameCache() : null);
-    }
-  
+    /* ClassByNameCache Entry for caching class.forName results upon enableClassCaching */
+    private static final ClassByNameCache classByNameCache =
+            isClassCachingEnabled ? new ClassByNameCache() : null;
 
     /** if true LUDCL/forName results would be cached, true by default starting Java8 */
     private static final class GetClassCachingSettingAction
@@ -513,12 +510,12 @@ public class ObjectInputStream
      * latestUserDefinedLoader().
      *
      * @throws  ClassNotFoundException if the class of a serialized object
-     * 	   could not be found.
+     *     could not be found.
      * @throws  IOException if an I/O error occurs.
      *
      */
 
-    private static Object redirectedReadObject(ObjectInputStream iStream, Class caller)
+    private static Object redirectedReadObject(ObjectInputStream iStream, Class<?> caller)
             throws ClassNotFoundException, IOException
     {
         return iStream.readObject(Object.class, caller);
@@ -556,7 +553,7 @@ public class ObjectInputStream
      * @throws  ClassNotFoundException Class of a serialized object cannot be
      *          found.
      */
-    private final Object readObject(Class<?> type, Class caller)
+    private final Object readObject(Class<?> type, Class<?> caller)
         throws IOException, ClassNotFoundException
     {
         if (enableOverride) {
@@ -567,9 +564,9 @@ public class ObjectInputStream
             throw new AssertionError("internal error");
 
         ClassLoader oldCachedLudcl = null;
-	    boolean setCached = false;
-	
-	    if (((null == curContext) || refreshLudcl) && (isClassCachingEnabled)) {
+        boolean setCached = false;
+
+        if (((null == curContext) || refreshLudcl) && isClassCachingEnabled) {
             oldCachedLudcl = cachedLudcl;
 
             // If caller is not provided, follow the standard path to get the cachedLudcl.
@@ -577,7 +574,7 @@ public class ObjectInputStream
 
             if (caller == null) {
                  cachedLudcl = latestUserDefinedLoader();
-            }else{
+            } else {
                  cachedLudcl = caller.getClassLoader();
             }
 
@@ -693,9 +690,9 @@ public class ObjectInputStream
     public Object readUnshared() throws IOException, ClassNotFoundException {
 
         ClassLoader oldCachedLudcl = null;
-        boolean setCached = false; 
+        boolean setCached = false;
 
-        if (((null == curContext) || refreshLudcl) && (isClassCachingEnabled)) {
+        if (((null == curContext) || refreshLudcl) && isClassCachingEnabled) {
             oldCachedLudcl = cachedLudcl;
             cachedLudcl = latestUserDefinedLoader();
             setCached = true;

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
  * ===========================================================================
  */
 
@@ -1854,7 +1854,7 @@ public final class String
 			} while (quot != 0);
 
 			if (v1 < 0) {
-				helpers.putCharInArrayByIndex(value, index, (char) '-');
+				helpers.putCharInArrayByIndex(value, index, '-');
 			}
 
 			// Copy in s1 contents
@@ -2013,7 +2013,7 @@ public final class String
 			} while (quot2 != 0);
 
 			if (v2 < 0) {
-				helpers.putCharInArrayByIndex(value, index2--, (char) '-');
+				helpers.putCharInArrayByIndex(value, index2--, '-');
 			}
 
 			// Copy in s1 contents
@@ -2040,7 +2040,7 @@ public final class String
 			} while (quot1 != 0);
 
 			if (v1 < 0) {
-				helpers.putCharInArrayByIndex(value, index1--, (char) '-');
+				helpers.putCharInArrayByIndex(value, index1--, '-');
 			}
 
 			if (COMPACT_STRINGS) {


### PR DESCRIPTION
Prior to this change, we see these warnings relating to patches to java code in this repository for openj9:
```
.../jdk17/src/java.base/share/classes/java/io/ObjectInputStream.java:374: warning: [removal] AccessController in java.security has been deprecated and marked for removal
.../jdk17/src/java.base/share/classes/java/io/ObjectInputStream.java:521: warning: [rawtypes] found raw type: Class
.../jdk17/src/java.base/share/classes/java/io/ObjectInputStream.java:559: warning: [rawtypes] found raw type: Class
.../jdk17/src/java.base/share/classes/java/lang/String.java:1857: warning: [cast] redundant cast to char
.../jdk17/src/java.base/share/classes/java/lang/String.java:2016: warning: [cast] redundant cast to char
.../jdk17/src/java.base/share/classes/java/lang/String.java:2043: warning: [cast] redundant cast to char
````

Also some minor cleanup for whitespace.