### PR TITLE
Add NotCheckpointSafe to prevent JVMCheckpointException/deadlock

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -51,8 +51,11 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 	SRC := $(TOPDIR), \
 	DEST := $(SUPPORT_OUTPUTDIR)/overlay, \
 	FILES := \
+		src/java.base/share/classes/java/lang/ClassValue.java \
+		src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java \
 		src/java.base/share/classes/java/security/Security.java \
 		src/java.base/share/classes/java/util/Timer.java \
+		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
 		src/java.base/share/classes/java/util/TimerTask.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
 	))

--- a/src/java.base/share/classes/java/lang/ClassValue.java
+++ b/src/java.base/share/classes/java/lang/ClassValue.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang;
 
 import java.util.WeakHashMap;
@@ -33,6 +39,10 @@ import jdk.internal.misc.Unsafe;
 
 import static java.lang.ClassValue.ClassValueMap.probeHomeLocation;
 import static java.lang.ClassValue.ClassValueMap.probeBackupLocations;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT*/
 
 /**
  * Lazily associate a computed value with (potentially) every type.
@@ -372,6 +382,9 @@ public abstract class ClassValue<T> {
 
     private static final Object CRITICAL_SECTION = new Object();
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT*/
     private static ClassValueMap initializeMap(Class<?> type) {
         ClassValueMap map;
         synchronized (CRITICAL_SECTION) {  // private object to avoid deadlocks

--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import jdk.internal.access.SharedSecrets;
@@ -52,6 +58,10 @@ import static java.lang.invoke.MethodHandleNatives.Constants.REF_putStatic;
 import static java.lang.invoke.MethodHandleStatics.*;
 import static java.lang.invoke.MethodHandles.Lookup.IMPL_LOOKUP;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT*/
 
 /**
  * Class specialization code.
@@ -159,6 +169,9 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
         }
     };
 
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT*/
     public final S findSpecies(K key) {
         // Note:  Species instantiation may throw VirtualMachineError because of
         // code cache overflow.  If this happens the species bytecode may be

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -33,6 +33,12 @@
  * http://creativecommons.org/publicdomain/zero/1.0/
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util.concurrent;
 
 import java.io.ObjectStreamField;
@@ -69,6 +75,10 @@ import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 import jdk.internal.misc.Unsafe;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT*/
 
 /**
  * A hash table supporting full concurrency of retrievals and
@@ -1688,6 +1698,9 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @throws RuntimeException or Error if the mappingFunction does so,
      *         in which case the mapping is left unestablished
      */
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT*/
     public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
         if (key == null || mappingFunction == null)
             throw new NullPointerException();


### PR DESCRIPTION
Annotated `java.lang.ClassValue.initializeMap()`, `java.lang.invoke.ClassSpecializer.findSpecies()` & `java.util.concurrent.ConcurrentHashMap.computeIfAbsent()` with `NotCheckpointSafe`.

Related https://github.com/eclipse-openj9/openj9/issues/15568
Depends https://github.com/eclipse-openj9/openj9/pull/15593

Signed-off-by: Jason Feng <fengj@ca.ibm.com>