### PR TITLE
Add NotCheckpointSafe annotations & JPP support for generated source

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -51,9 +51,12 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 	SRC := $(TOPDIR), \
 	DEST := $(SUPPORT_OUTPUTDIR)/overlay, \
 	FILES := \
+		src/java.base/share/classes/java/lang/ClassValue.java \
+		src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java \
 		src/java.base/share/classes/java/security/Security.java \
 		src/java.base/share/classes/java/util/Timer.java \
 		src/java.base/share/classes/java/util/TimerTask.java \
+		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
 	))
 

--- a/make/modules/java.base/gensrc/GensrcCharsetMapping.gmk
+++ b/make/modules/java.base/gensrc/GensrcCharsetMapping.gmk
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+# ===========================================================================
+
 ################################################################################
 #
 # Generate StandardCharsets.java and individul sun.nio.cs charset class using
@@ -40,6 +44,26 @@ CHARSET_STANDARD_JAVA_TEMPLATES := \
     $(TOPDIR)/src/java.base/share/classes/sun/nio/cs/StandardCharsets.java.template
 CHARSET_STANDARD_OS := stdcs-$(OPENJDK_TARGET_OS)
 
+J9TOOLS_DIR := $(SUPPORT_OUTPUTDIR)/j9tools
+JPP_JAR     := $(J9TOOLS_DIR)/jpp.jar
+JPP_TAGS    := PLATFORM-$(OPENJ9_PLATFORM_CODE)
+
+define RunJPP
+	@$(BOOT_JDK)/bin/java \
+		-cp "$(call FixPath,$(JPP_JAR))" \
+		-Dfile.encoding=US-ASCII \
+		com.ibm.jpp.commandline.CommandlineBuilder \
+			-verdict \
+			-config $1 \
+			-baseDir "$(call FixPath,$(dir $2))" \
+			-srcRoot $(notdir $2)/ \
+			-xml "$(call FixPath,$(OPENJ9_TOPDIR)/jcl/jpp_configuration.xml)" \
+			-dest "$(call FixPath,$(SUPPORT_OUTPUTDIR)$(strip $3))" \
+			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))" \
+			-includeIfUnsure \
+			-noWarnIncludeIf
+endef # RunJPP
+
 $(CHARSET_DONE_BASE)-stdcs: $(CHARSET_DATA_DIR)/charsets \
     $(wildcard $(CHARSET_DATA_DIR)/$(CHARSET_STANDARD_OS)) \
     $(CHARSET_TEMPLATES) $(CHARSET_STANDARD_JAVA_TEMPLATES) \
@@ -51,6 +75,10 @@ $(CHARSET_DONE_BASE)-stdcs: $(CHARSET_DATA_DIR)/charsets \
 	    $(CHARSET_STANDARD_JAVA_TEMPLATES) $(CHARSET_EXTSRC_DIR) \
 	    $(CHARSET_COPYRIGHT_HEADER) \
             $(LOG_DEBUG)
+	$(MKDIR) -p $(SUPPORT_OUTPUTDIR)/overlay-gensrc/src/java.base/sun/nio/cs
+	$(CP) $(CHARSET_GENSRC_JAVA_DIR_BASE)/StandardCharsets.java $(SUPPORT_OUTPUTDIR)/overlay-gensrc/src/java.base/sun/nio/cs/
+	$(call RunJPP, JAVA$(VERSION_FEATURE), $(SUPPORT_OUTPUTDIR)/overlay-gensrc, /overlay-result)
+	$(CP) $(SUPPORT_OUTPUTDIR)/overlay-result/java.base/sun/nio/cs/StandardCharsets.java $(CHARSET_GENSRC_JAVA_DIR_BASE)/
 	$(TOUCH) '$@'
 
 TARGETS += $(CHARSET_DONE_BASE)-stdcs

--- a/src/java.base/share/classes/java/lang/ClassValue.java
+++ b/src/java.base/share/classes/java/lang/ClassValue.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang;
 
 import java.util.WeakHashMap;
@@ -33,6 +39,10 @@ import jdk.internal.misc.Unsafe;
 
 import static java.lang.ClassValue.ClassValueMap.probeHomeLocation;
 import static java.lang.ClassValue.ClassValueMap.probeBackupLocations;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * Lazily associate a computed value with (potentially) every type.
@@ -372,6 +382,9 @@ public abstract class ClassValue<T> {
 
     private static final Object CRITICAL_SECTION = new Object();
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     private static ClassValueMap initializeMap(Class<?> type) {
         ClassValueMap map;
         synchronized (CRITICAL_SECTION) {  // private object to avoid deadlocks

--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import jdk.internal.access.SharedSecrets;
@@ -52,6 +58,10 @@ import static java.lang.invoke.MethodHandleNatives.Constants.REF_putStatic;
 import static java.lang.invoke.MethodHandleStatics.*;
 import static java.lang.invoke.MethodHandles.Lookup.IMPL_LOOKUP;
 import static jdk.internal.org.objectweb.asm.Opcodes.*;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * Class specialization code.
@@ -159,6 +169,9 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
         }
     };
 
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     public final S findSpecies(K key) {
         // Note:  Species instantiation may throw VirtualMachineError because of
         // code cache overflow.  If this happens the species bytecode may be

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -33,6 +33,12 @@
  * http://creativecommons.org/publicdomain/zero/1.0/
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util.concurrent;
 
 import java.io.ObjectStreamField;
@@ -69,6 +75,10 @@ import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 import jdk.internal.misc.Unsafe;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /**
  * A hash table supporting full concurrency of retrievals and
@@ -1688,6 +1698,9 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * @throws RuntimeException or Error if the mappingFunction does so,
      *         in which case the mapping is left unestablished
      */
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
         if (key == null || mappingFunction == null)
             throw new NullPointerException();

--- a/src/java.base/share/classes/sun/nio/cs/StandardCharsets.java.template
+++ b/src/java.base/share/classes/sun/nio/cs/StandardCharsets.java.template
@@ -25,6 +25,12 @@
  *
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 // -- This file was mechanically generated: Do not edit! -- //
 
 package sun.nio.cs;
@@ -35,6 +41,10 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import jdk.internal.vm.annotation.Stable;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 public class StandardCharsets extends CharsetProvider {
 
@@ -165,6 +175,9 @@ public class StandardCharsets extends CharsetProvider {
         return cs;
     }
 
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     public final Charset charsetForName(String charsetName) {
         synchronized (this) {
             return lookup(charsetName);


### PR DESCRIPTION
Annotated `java.lang.ClassValue.initializeMap()`, `java.lang.invoke.ClassSpecializer.findSpecies()`, and `java.util.concurrent.ConcurrentHashMap.computeIfAbsent()` with `NotCheckpointSafe` to prevent `JVMCheckpointException`/deadlock;
Added `CRIU` `JPP` flag at `StandardCharsets.java.template`;
Modified `GensrcCharsetMapping.gmk` to run JPP after `StandardCharsets.java` generation.

FYI @tajila 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>