### PR TITLE
Add NULL check for CRIU field retrieval

### DIFF
--- a/src/java.base/share/classes/java/util/Timer.java
+++ b/src/java.base/share/classes/java/util/Timer.java
@@ -214,7 +214,9 @@ public class Timer {
             throw new IllegalArgumentException("Negative delay.");
         /*[IF CRIU_SUPPORT]*/
         // only tasks scheduled before Checkpoint to be adjusted
-        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+        if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
+            && (task != null)
+        ) {
             task.criuAdjustRequired = true;
         }
         /*[ENDIF] CRIU_SUPPORT*/
@@ -275,7 +277,9 @@ public class Timer {
             throw new IllegalArgumentException("Non-positive period.");
         /*[IF CRIU_SUPPORT]*/
         // only tasks scheduled before Checkpoint to be adjusted
-        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+        if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
+            && (task != null)
+        ) {
             task.criuAdjustRequired = true;
         }
         /*[ENDIF] CRIU_SUPPORT*/
@@ -361,7 +365,9 @@ public class Timer {
             throw new IllegalArgumentException("Non-positive period.");
         /*[IF CRIU_SUPPORT]*/
         // only tasks scheduled before Checkpoint to be adjusted
-        if (InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0) {
+        if ((InternalCRIUSupport.getCheckpointRestoreNanoTimeDelta() == 0)
+            && (task != null)
+        ) {
             task.criuAdjustRequired = true;
         }
         /*[ENDIF] CRIU_SUPPORT*/


### PR DESCRIPTION
The task could be null.

Cherry-pick https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/561

Signed-off-by: Jason Feng <fengj@ca.ibm.com>