### PR TITLE
(0.33) Fix race condition when creating the native pointer for an EC key, and FIPS updates

### DIFF
--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPrivateKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPrivateKeyImpl.java
@@ -229,9 +229,9 @@ public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
      * @return the native EC public key context pointer or -1 on error
      */
     long getNativePtr() {
-        if (nativeECKey == 0x0) {
+        if (this.nativeECKey == 0x0) {
             synchronized (this) {
-                if (nativeECKey == 0x0) {
+                if (this.nativeECKey == 0x0) {
                     ECPoint generator = this.params.getGenerator();
                     EllipticCurve curve = this.params.getCurve();
                     ECField field = curve.getField();
@@ -241,26 +241,27 @@ public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
                     byte[] gy = generator.getAffineY().toByteArray();
                     byte[] n = this.params.getOrder().toByteArray();
                     byte[] h = BigInteger.valueOf(this.params.getCofactor()).toByteArray();
-                    byte[] p = new byte[0];
+                    long nativePointer;
                     if (field instanceof ECFieldFp) {
-                        p = ((ECFieldFp)field).getP().toByteArray();
-                        nativeECKey = nativeCrypto.ECEncodeGFp(a, a.length, b, b.length, p, p.length, gx, gx.length, gy, gy.length, n, n.length, h, h.length);
+                        byte[] p = ((ECFieldFp)field).getP().toByteArray();
+                        nativePointer = nativeCrypto.ECEncodeGFp(a, a.length, b, b.length, p, p.length, gx, gx.length, gy, gy.length, n, n.length, h, h.length);
                     } else if (field instanceof ECFieldF2m) {
-                        p = ((ECFieldF2m)field).getReductionPolynomial().toByteArray();
-                        nativeECKey = nativeCrypto.ECEncodeGF2m(a, a.length, b, b.length, p, p.length, gx, gx.length, gy, gy.length, n, n.length, h, h.length);
+                        byte[] p = ((ECFieldF2m)field).getReductionPolynomial().toByteArray();
+                        nativePointer = nativeCrypto.ECEncodeGF2m(a, a.length, b, b.length, p, p.length, gx, gx.length, gy, gy.length, n, n.length, h, h.length);
                     } else {
-                        nativeECKey = -1;
+                        nativePointer = -1;
                     }
-                    if (nativeECKey != -1) {
-                        nativeCrypto.createECKeyCleaner(this, nativeECKey);
+                    if (nativePointer != -1) {
+                        nativeCrypto.createECKeyCleaner(this, nativePointer);
                         byte[] value = this.getS().toByteArray();
-                        if (nativeCrypto.ECCreatePrivateKey(nativeECKey, value, value.length) == -1) {
-                            nativeECKey = -1;
+                        if (nativeCrypto.ECCreatePrivateKey(nativePointer, value, value.length) == -1) {
+                            nativePointer = -1;
                         }
                     }
+                    this.nativeECKey = nativePointer;
                 }
             }
         }
-        return nativeECKey;
+        return this.nativeECKey;
     }
 }

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPublicKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPublicKeyImpl.java
@@ -153,9 +153,9 @@ public final class ECPublicKeyImpl extends X509Key implements ECPublicKey {
      * @return the native EC public key context pointer or -1 on error
      */
     long getNativePtr() {
-        if (nativeECKey == 0x0) {
+        if (this.nativeECKey == 0x0) {
             synchronized (this) {
-                if (nativeECKey == 0x0) {
+                if (this.nativeECKey == 0x0) {
                     ECPoint generator = this.params.getGenerator();
                     EllipticCurve curve = this.params.getCurve();
                     ECField field = curve.getField();
@@ -165,29 +165,30 @@ public final class ECPublicKeyImpl extends X509Key implements ECPublicKey {
                     byte[] gy = generator.getAffineY().toByteArray();
                     byte[] n = this.params.getOrder().toByteArray();
                     byte[] h = BigInteger.valueOf(this.params.getCofactor()).toByteArray();
-                    byte[] p = new byte[0];
+                    long nativePointer;
                     int fieldType = 0;
                     if (field instanceof ECFieldFp) {
-                        p = ((ECFieldFp)field).getP().toByteArray();
-                        nativeECKey = nativeCrypto.ECEncodeGFp(a, a.length, b, b.length, p, p.length, gx, gx.length, gy, gy.length, n, n.length, h, h.length);
+                        byte[] p = ((ECFieldFp)field).getP().toByteArray();
+                        nativePointer = nativeCrypto.ECEncodeGFp(a, a.length, b, b.length, p, p.length, gx, gx.length, gy, gy.length, n, n.length, h, h.length);
                     } else if (field instanceof ECFieldF2m) {
                         fieldType = 1;
-                        p = ((ECFieldF2m)field).getReductionPolynomial().toByteArray();
-                        nativeECKey = nativeCrypto.ECEncodeGF2m(a, a.length, b, b.length, p, p.length, gx, gx.length, gy, gy.length, n, n.length, h, h.length);
+                        byte[] p = ((ECFieldF2m)field).getReductionPolynomial().toByteArray();
+                        nativePointer = nativeCrypto.ECEncodeGF2m(a, a.length, b, b.length, p, p.length, gx, gx.length, gy, gy.length, n, n.length, h, h.length);
                     } else {
-                        nativeECKey = -1;
+                        nativePointer = -1;
                     }
-                    if (nativeECKey != -1) {
-                        nativeCrypto.createECKeyCleaner(this, nativeECKey);
+                    if (nativePointer != -1) {
+                        nativeCrypto.createECKeyCleaner(this, nativePointer);
                         byte[] x = this.w.getAffineX().toByteArray();
                         byte[] y = this.w.getAffineY().toByteArray();
-                        if (nativeCrypto.ECCreatePublicKey(nativeECKey, x, x.length, y, y.length, fieldType) == -1) {
-                            nativeECKey = -1;
+                        if (nativeCrypto.ECCreatePublicKey(nativePointer, x, x.length, y, y.length, fieldType) == -1) {
+                            nativePointer = -1;
                         }
                     }
+                    this.nativeECKey = nativePointer;
                 }
             }
         }
-        return nativeECKey;
+        return this.nativeECKey;
     }
 }

--- a/test/jdk/ProblemList-fips.txt
+++ b/test/jdk/ProblemList-fips.txt
@@ -525,11 +525,6 @@ javax/crypto/KeyGenerator/TestKGParity.java https://github.com/ibmruntimes/openj
 # Related to exist testing jar
 java/security/Provider/SecurityProviderModularTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
 
-# AES-GCM is a non-Approved mode in FIPS mode
-com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
-com/sun/crypto/provider/Cipher/AEAD/GCMShortBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
-com/sun/crypto/provider/Cipher/AEAD/OverlapByteBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
-
 # MessageDigest, Signature Engines are not supported in FIPS mode
 java/security/MessageDigest/TestCloneable.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
 java/security/Signature/TestCloneable.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
@@ -542,3 +537,497 @@ javax/crypto/KeyGenerator/CompareKeys.java https://github.com/ibmruntimes/openj9
 # If the ciphertext input is not a multiple of block size during the Cipher.DECRYPT_MODE, the CKR_ENCRYPTED_DATA_LEN_RANGE will return.
 # PKCS11 spec link https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/os/pkcs11-base-v3.0-os.html
 javax/crypto/CipherSpi/ResetByteBuffer.java.ResetByteBuffer https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+#
+# Exclude tests list from extended.openjdk when jdk_security3 enabled
+#
+
+# NoSuchAlgorithmException: no such algorithm: DSA, MD2, SHA, SHA-256, MD5 for provider SUN.
+
+com/sun/org/apache/xml/internal/security/ShortECDSA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/org/apache/xml/internal/security/SignatureKeyInfo.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/org/apache/xml/internal/security/TruncateHMAC.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/MessageDigest/ReinitDigest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Signature/TestDSAKeyLength.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/DSA/SupportedDSAParamGen.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/DSA/SupportedDSAParamGenLongKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/DSA/TestAlgParameterGenerator.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/DSA/TestDSA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/DSA/TestDSA2.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/DSA/TestKeyPairGenerator.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/DSA/TestLegacyDSAKeyPairGenerator.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/MessageDigest/DigestKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/MessageDigest/Offsets.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/MessageDigest/TestSHAClone.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/NSASuiteB/TestDSAGenParameterSpec.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/NSASuiteB/TestDSAGenParameterSpecLongKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/NSASuiteB/TestSHAOids.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/NSASuiteB/TestSHAwithDSASignatureOids.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Module java.security.sasl related. Unable to find client impl for CRAM-MD5 or DIGEST-MD5.
+
+com/sun/security/sasl/Cram.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/digest/AuthNoUtf8.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/digest/AuthOnly.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/digest/AuthRealmChoices.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/digest/AuthRealms.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/digest/CheckNegotiatedQOPs.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/digest/Integrity.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/digest/NoQuoteParams.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/digest/Privacy.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/digest/PrivacyRc4.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/digest/Unbound.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/ntlm/Conformance.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/sasl/ntlm/NTLMTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/security/sasl/Sasl/ClientServerTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/security/sasl/Sasl/DisabledMechanisms.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# NoSuchAlgorithmException: JKS KeyStore not available or KeyStore file related.
+
+javax/net/ssl/ALPN/SSLEngineAlpnTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ALPN/SSLServerSocketAlpnTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ALPN/SSLSocketAlpnTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ciphersuites/DisabledAlgorithms.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ciphersuites/ECCurvesconstraints.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/compatibility/ClientHelloProcessing.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/CipherSuite.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/ClientAuth.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSBufferOverflowUnderflowTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSDataExchangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSEnginesClosureTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSHandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSHandshakeWithReplicatedPacketsTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSIncorrectAppDataTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSMFLNTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSNotEnabledRC4Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSOverDatagram.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSRehandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSRehandshakeWithCipherChangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSRehandshakeWithDataExTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSSequenceNumberTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/DTLSUnsupportedCiphersTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/InvalidCookie.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/NoMacInitialClientHello.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/PacketLossRetransmission.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/Reordered.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/RespondToRetransmit.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/Retransmission.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLS/WeakCipherSuite.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10BufferOverflowUnderflowTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10DataExchangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10EnginesClosureTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10HandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10HandshakeWithReplicatedPacketsTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10IncorrectAppDataTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10MFLNTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10NotEnabledRC4Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10RehandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10RehandshakeWithCipherChangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10RehandshakeWithDataExTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10SequenceNumberTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/DTLSv10/DTLSv10UnsupportedCiphersTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/finalize/SSLSessionFinalizeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/FixingJavadocs/ImplicitHandshake.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/FixingJavadocs/KMTMGetNothing.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/FixingJavadocs/SSLSessionNulls.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/HttpsURLConnection/Equals.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/HttpsURLConnection/GetResponseCode.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/interop/ClientHelloBufferUnderflowException.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/interop/ClientHelloChromeInterOp.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/sanity/ciphersuites/SystemPropCipherSuitesOrder.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/sanity/ciphersuites/TLSCipherSuitesOrder.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/sanity/interop/ClientJSSEServerJSSE.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ServerName/BestEffortOnLazyConnected.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ServerName/SSLEngineExplorer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ServerName/SSLSocketConsistentSNI.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ServerName/SSLSocketExplorer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ServerName/SSLSocketExplorerFailure.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ServerName/SSLSocketExplorerMatchedSNI.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ServerName/SSLSocketExplorerWithCliSNI.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ServerName/SSLSocketExplorerWithSrvSNI.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/ServerName/SSLSocketSNISensitive.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLEngine/ArgCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLEngine/Arrays.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLEngine/ExtendedKeyEngine.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLEngine/ExtendedKeySocket.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLEngine/LargeBufs.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLEngine/LargePacket.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLEngine/NoAuthClientAuth.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLParameters/UseCipherSuitesOrder.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSession/HttpsURLConnectionLocalCertificateChain.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSession/JSSERenegotiate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSession/RenegotiateTLS13.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSession/ResumeTLS13withSNI.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSession/SessionCacheSizeTests.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSession/SessionTimeOutTests.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSession/SSLCtxAccessToSessCtx.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSession/TestEnabledProtocols.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSocket/ClientExcOnAlert.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSocket/InputStreamClosure.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSocket/OutputStreamClosure.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/SSLSocket/Tls13PacketSize.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/templates/SSLEngineTemplate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/templates/SSLSocketSSLEngineTemplate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/templates/SSLSocketTemplate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TestJSSEClientDefaultProtocol.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TestJSSEClientProtocol.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TestJSSENoCommonProtocols.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TestJSSEServerProtocol.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TLSDataExchangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TLSEnginesClosureTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TLSHandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TLSMFLNTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TLSNotEnabledRC4Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TLSRehandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TLSRehandshakeWithCipherChangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TLSRehandshakeWithDataExTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLS/TLSUnsupportedCiphersTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSCommon/ConcurrentClientAccessTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSCommon/TestSessionLocalPrincipal.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSCommon/TLSTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv1/TLSDataExchangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv1/TLSEnginesClosureTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv1/TLSHandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv1/TLSMFLNTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv1/TLSNotEnabledRC4Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv1/TLSRehandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv1/TLSRehandshakeWithCipherChangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv1/TLSRehandshakeWithDataExTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv1/TLSUnsupportedCiphersTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/EmptyCertificateAuthorities.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/GenericBlockCipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/GenericStreamCipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/TLSDataExchangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/TLSEnginesClosureTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/TLSHandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/TLSMFLNTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/TLSNotEnabledRC4Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/TLSRehandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/TLSRehandshakeWithCipherChangeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/TLSRehandshakeWithDataExTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv11/TLSUnsupportedCiphersTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv12/DisabledShortDSAKeys.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv12/DisabledShortRSAKeys.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv12/ProtocolFilter.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv12/ShortRSAKey512.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv12/ShortRSAKeyGCM.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv12/SignatureAlgorithms.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/TLSv12/TLSEnginesClosureTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+jdk/security/logging/TestTLSHandshakeLog.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/rsa/TestKeyFactory.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/rsa/TestSignatures.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/KeyStore/CaseSensitiveAliases.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/KeyStore/DKSTest.sh https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/KeyStore/TestJKSWithSecretKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/KeyStore/WrongPassword.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/X509Factory/BadPem.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/X509Factory/BigCRL.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/TestKeyFactory.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/TestSignatures.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/ALPN/AlpnGreaseTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/CertPathRestrictions/TLSRestrictions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/CipherSuite/DisabledCurve.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/CipherSuite/NamedGroupsWithCipherSuite.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/CipherSuite/RestrictNamedGroup.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/CipherSuite/SupportedGroups.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/ClientHandshaker/CipherSuiteOrder.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/ClientHandshaker/LengthCheckTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/ClientHandshaker/RSAExport.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/DHKeyExchange/DHEKeySizing.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/DHKeyExchange/LegacyDHEKeyExchange.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/DHKeyExchange/UseStrongDHSizes.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/EngineArgs/DebugReportsOneExtraByte.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/GenSSLConfigs/main.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/HandshakeOutStream/NullCerts.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/InputRecord/ClientHelloRead.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/ProtocolVersion/HttpsProtocols.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/ServerHandshaker/AnonCipherWithWantClientAuth.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/ServerHandshaker/GetPeerHost.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/ServerHandshaker/HelloExtensionsTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SignatureScheme/CustomizedClientSchemes.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SignatureScheme/CustomizedServerSchemes.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SignatureScheme/Tls13NamedGroups.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLContextImpl/MD2InTrustAnchor.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLContextImpl/TrustTrustedCert.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/CloseEngineException.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/CloseStart.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/DelegatedTaskWrongException.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/EmptyExtensionData.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/EngineEnforceUseClientMode.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/RehandshakeFinished.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/SSLEngineBadBufferArrayAccess.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/SSLEngineDeadlock.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/SSLEngineFailedALPN.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/SSLEngineKeyLimit.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLEngineImpl/TLS13BeginHandshake.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLLogger/LoggingFormatConsistency.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSessionImpl/InvalidateSession.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/ClientSocketCloseHang.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/DisableExtensions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/SocketExceptionForSocketIssues.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/SSLSocketBruceForceClose.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/SSLSocketClose.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/SSLSocketKeyLimit.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509KeyManager/CertificateAuthorities.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509KeyManager/PreferredKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509KeyManager/SelectOneKeyOutOfMany.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509TrustManagerImpl/BasicConstraints.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509TrustManagerImpl/CertRequestOverflow.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509TrustManagerImpl/CheckNullEntity.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509TrustManagerImpl/ComodoHacker.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509TrustManagerImpl/PKIXExtendedTM.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509TrustManagerImpl/SelfIssuedCert.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509TrustManagerImpl/SunX509ExtendedTM.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509TrustManagerImpl/TooManyCAs.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/X509TrustManagerImpl/X509ExtendedTMEnabled.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/jarsigner/multiRelease/MVJarSigningTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/jarsigner/warnings/NoTimestampTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/CacertsOption.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/CloneKeyAskPassword.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/HasSrcStoretypeOption.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/ImportPrompt.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/PrintSSL.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/StartDateTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/WeakAlg.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/validator/certreplace.sh https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/validator/EndEntityExtensionCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/validator/samedn.sh https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Related to SunJCE.
+
+javax/net/ssl/Stapling/HttpsUrlConnClient.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/Stapling/SSLEngineWithStapling.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/Stapling/SSLSocketWithStapling.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+javax/net/ssl/Stapling/StapleEnableProps.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/jca/PreferredProviderNegativeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/jca/PreferredProviderTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Check Cipher Suites mismatch.
+
+javax/net/ssl/sanity/ciphersuites/CheckCipherSuites.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# no such provider: SunRsaSign or Provider SunRsaSign not found.
+
+javax/security/auth/login/Configuration/GetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Signature/SigInteropPSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/KeySizeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/PrivateKeyEqualityTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/pss/PSSKeyCompatibility.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/pss/PSSParametersTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/pss/SerializedPSSKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/pss/SignatureTest2.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/pss/SignatureTestPSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/pss/TestPSSKeySupport.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/pss/TestSigGenPSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/SignatureTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/SignedObjectChain.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/SpecTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/TestKeyPairGenerator.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/TestKeyPairGeneratorExponent.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/TestKeyPairGeneratorInit.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/TestKeyPairGeneratorLength.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/rsa/TestSigGen15.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/x509/X509CertImpl/Verify.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/x509/X509CRLImpl/Verify.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Jar sign related.
+
+jdk/security/jarsigner/Function.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+jdk/security/jarsigner/JarWithOneNonDisabledDigestAlg.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+jdk/security/jarsigner/Spec.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# no such algorithm: EC, SHA384withECDSAinP1363Format, NONEwithECDSA, ECDH, XDH KeyPairGenerator for provider SunEC.
+# Because removed SunEC KeyPairGenerator, KeyAgreement and Signature. The SunPKCS11 has its own EC KeyPairGenerator.
+
+sun/security/ec/InvalidCurve.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ec/NSASuiteB/TestSHAwithECDSASignatureOids.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ec/SignatureDigestTruncate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ec/SignatureOffsets.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ec/SignedObjectChain.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ec/TestEC.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ec/xec/TestXDH.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Non-PKCS11 key related.
+
+sun/security/pkcs/pkcs10/PKCS10AttrEncoding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs/pkcs7/PKCS7VerifyTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs/pkcs7/SignerOrder.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs/pkcs8/PKCS8Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs/pkcs8/TestLeadingZeros.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/Bug6415637.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/EmptyPassword.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/KeytoolOpensslInteropTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/P12SecretKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/PBES2Encoding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/PKCS12SameKeyId.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/ProbeLargeKeystore.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/StorePasswordTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/StoreSecretKeyTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/StoreTrustedCertTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs12/WrongPBES2.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# No such provider: SunJCE.
+
+sun/security/pkcs11/Cipher/EncryptionPadding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestPKCS5PaddingError.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestRawRSACipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestRSACipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestRSACipherWrap.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestSymmCiphers.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/KeyAgreement/TestInterop.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Test ChaCha related.
+
+sun/security/pkcs11/Cipher/TestChaChaPoly.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestChaChaPolyKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestChaChaPolyNoReuse.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestChaChaPolyOutputSize.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/KeyGenerator/TestChaCha20.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# NoSuchAlgorithmException: PBE, PBEWithHmacSHA256AndAES_256, PBES2 AlgorithmParameters not available.
+
+sun/security/pkcs11/ec/ReadPKCS12.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/CipherSuite/RestrictSignatureScheme.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/Stapling/StatusResponseManager.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/CheckCertAKID.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/fakegen/PSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/GroupName.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/JKStoPKCS12.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/PKCS12Passwd.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/StorePasswords.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Policy file related. Failed due to related to the keystore files.
+
+sun/security/provider/PolicyFile/Alias.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/PolicyFile/AliasExpansion.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/PolicyFile/TokenStore.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/PolicyFile/TrustedCert.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# NoSuchAlgorithmException: DRBG, SHA1PRNG, NativePRNG SecureRandom not available.
+
+sun/security/provider/SecureRandom/AutoReseed.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/SecureRandom/CommonSeeder.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/SecureRandom/DRBGAlg.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/SecureRandom/SHA1PRNGReseed.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/SecureRandom/StrongSecureRandom.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/SecureRandom/StrongSeedReader.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/SeedGenerator/SeedGeneratorChoice.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# javax.net.ssl.SSLHandshakeException: no cipher suites in common.
+# javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure.
+# All the below hard coded static String keyStoreFile = "keystore"; in the test codes. In FIPS mode, keystore must be NONE.
+
+sun/security/ssl/AppInputStream/ReadZeroBytes.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/AppInputStream/RemoveMarkReset.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/AppOutputStream/NoExceptionOnClose.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/InputRecord/SSLSocketTimeoutNulls.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SocketCreation/SocketCreation.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/spi/ProviderInit.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSessionImpl/HashCodeMissing.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSessionImpl/ResumeChecksClient.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSessionImpl/ResumeChecksServer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/AsyncSSLSocketClose.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/BlockedAsyncClose.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/ClientModeClientAuth.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/ClientTimeout.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/CloseSocketException.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/InvalidateServerSessionRenegotiate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/LargePacketAfterHandshakeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/NewSocketMethods.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/NoImpactServerRenego.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/NotifyHandshakeTest.sh https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/RejectClientRenego.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/ReuseAddr.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/ReverseNameLookup.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/ServerRenegoWithTwoVersions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/ServerTimeout.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/SSLSocketCloseHang.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/ssl/SSLSocketImpl/UnconnectedSocketWrongExceptions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/util/HostnameMatcher/NullHostnameCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Hard coded provider SUN in test codes.
+
+sun/security/ssl/SSLContextImpl/GoodProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Initialization failed PKCS11Exception: CKR_SLOT_ID_INVALID.
+# All the below tests will call PKCS11Test.getSunPKCS11(PKCS11Test.java:199) to get the SunPKCS11 provider.
+# When testing in the FIPS mode, the SunPKCS11 will first be initialized as a FIPS provider SunPKCS11-NSS-FIPS.
+# And then in the test code PKCS11Test, line 199. It will try to configure the SunPKCS11 using the p11-nss.txt to the NSS mode.
+# But in the FIPS mode, there can only be a single PKCS11 provider. So configure the SunPKCS11 to the NSS mode will failed.
+
+sun/security/pkcs11/SampleTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/tls/TestPremaster.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Signature/TestDSA2.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Signature/TestRSAKeyLength.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Signature/SignatureTestPSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Signature/KeyAndParamCheckForPSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Signature/ReinitSignature.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Signature/ByteBuffers.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Signature/InitAgainPSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/SecureRandom/Basic.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/SecureRandom/TestDeserialization.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Serialize/SerializeProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/rsa/TestKeyPairGenerator.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/rsa/TestCACerts.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/rsa/KeyWrap.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Provider/ConfigQuotedString.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Provider/Login.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/MessageDigest/ByteBuffers.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/MessageDigest/DigestKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/MessageDigest/TestCloning.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/KeyStore/Basic.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/KeyStore/ClientAuth.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/KeyGenerator/TestKeyGenerator.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/KeyAgreement/UnsupportedDHKeys.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/ec/TestECGenSpec.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/ec/ReadCertificates.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestGCMKeyAndIvCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestKATForGCM.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/ReinitCipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/Test4512704.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestCICOWithGCM.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Cipher/TestCICOWithGCMAndAAD.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# NSS module initial failures.
+# It using "nss.cfg" as the configure file and in the FIPS mode, there can only be a single PKCS11 provider.
+
+sun/security/pkcs11/Secmod/TestNssDbSqlite.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Secmod/LoadKeystore.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Secmod/Crypto.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Secmod/GetPrivateKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Secmod/JksSetPrivateKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Secmod/AddPrivateKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Jarsigner related. Need keystore file.
+
+sun/security/tools/jarsigner/TsacertOptionTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/jarsigner/Test4431684.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/jarsigner/TimestampCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/jarsigner/LineBrokenMultiByteCharacter.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/jarsigner/DefaultSigalg.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/jarsigner/EntriesOrder.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/jarsigner/JarSigningNonAscii.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/jarsigner/LargeJarEntry.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# PKCS11Exception: CKR_ATTRIBUTE_VALUE_INVALID. ProviderException: Unknown mechanism: 20.
+# Due to open a keystore file.
+
+sun/security/tools/keytool/UnknownAndUnparseable.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/NewSize7.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/CloseFile.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/tools/keytool/DupImport.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# java.lang.RuntimeException: The ldap.host.for.crldp from CRLDP extension is not requested.
+
+sun/security/x509/URICertStore/ExtensionsWithLDAP.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# javax.security.auth.login.LoginException: if keyStoreType is PKCS11 then keyStoreURL must be NONE.
+
+com/sun/security/auth/module/KeyStoreLoginModule/OptionTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+com/sun/security/auth/module/KeyStoreLoginModule/ReadOnly.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64

--- a/test/jdk/ProblemList-fips.txt
+++ b/test/jdk/ProblemList-fips.txt
@@ -1031,3 +1031,45 @@ sun/security/x509/URICertStore/ExtensionsWithLDAP.java https://github.com/ibmrun
 
 com/sun/security/auth/module/KeyStoreLoginModule/OptionTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
 com/sun/security/auth/module/KeyStoreLoginModule/ReadOnly.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+#
+# Update the exclude tests list for extended.openjdk after jdk_security3 test target enabled
+#
+
+# Failed due to the test case try to initial SunPKCS11 using p11-nss.txt file
+# But in FIPS mode, SunPKCS11 already be initialized in FIPS mode, and can not be initialized again
+
+sun/security/pkcs11/ec/TestECDH.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# FIPS don't support exporting DES, DSA, secret, tls master keys, only support RSA keys
+
+sun/security/pkcs11/KeyGenerator/DESParity.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/tls/TestKeyMaterial.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/tls/TestMasterSecret.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/certpath/SunCertPathBuilderExceptionTest.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Testing unusual curves in FIPS mode
+
+sun/security/pkcs11/ec/TestCurves.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# FIPS dont support importing DH, EC, DSA, RSA keys - only support Secret keys
+
+sun/security/pkcs11/ec/TestECDSA.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/ec/TestECDSA2.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/ec/TestECDH2.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/Signature/TestDSA.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/pkcs11/tls/TestLeadingZeroesP11.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/provider/DSA/TestMaxLengthDER.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+sun/security/x509/X509CertImpl/ECSigParamsVerifyWithCert.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# A mismatch in the error message but the function is correct
+
+sun/security/pkcs11/rsa/TestP11KeyFactoryGetRSAKeySpec.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# Algorithm not supported in FIPS mode
+
+sun/security/provider/MessageDigest/SHA512.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64
+
+# FIPS unexpected provider error - not a FIPS test
+
+sun/security/ssl/HandshakeHash/HandshakeHashCloneExhaustion.java	https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64

--- a/test/jdk/ProblemList-fips.txt
+++ b/test/jdk/ProblemList-fips.txt
@@ -17,3 +17,528 @@
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
+
+#
+# Exclude tests list from sanity.openjdk
+#
+# SunJCE and SunRsaSign related
+
+com/sun/crypto/provider/Cipher/AEAD/Encrypt.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/GCMLargeDataKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/GCMParameterSpecTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/KeyWrapper.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/ReadWriteSkip.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/SameBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/SealedObjectTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/WrongAAD.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/CICO.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/CTR.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Padding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4511676.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4512524.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4512704.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4513830.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4517355.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4626070.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestAESCipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestAESCiphers/TestAESWithDefaultProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestAESCiphers/TestAESWithRemoveAddProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestCICOWithGCM.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestCICOWithGCMAndAAD.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestCopySafe.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestGCMKeyAndIvCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestISO10126Padding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestKATForECB_IV.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestKATForECB_VK.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestKATForECB_VT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestKATForGCM.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestNonexpanding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestSameBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestShortBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/Blowfish/BlowfishTestVector.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/Blowfish/TestCipherBlowfish.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/CTR/CounterMode.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/CTS/CTSMode.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/DESKeyCleanupTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/DESSecretKeySpec.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/DesAPITest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/DoFinalReturnLen.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/FlushBug.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/KeyWrapping.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/PaddingTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/Sealtest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/TestCipherDES.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/TestCipherDESede.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/TextPKCS5PaddingTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/KeyWrap/NISTWrapKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/KeyWrap/XMLEncKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/CheckPBEKeySize.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/DecryptWithoutParameters.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/NegativeLength.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBEInvalidParamsTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBEKeyCleanupTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBEKeyTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBEKeysAlgorithmNames.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBEParametersTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBES2Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBESameBuffer/PBESameBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBESealedObject.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBKDF2Translate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBMacBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBMacDoFinalVsUpdate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PKCS12Cipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PKCS12CipherKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PKCS12Oid.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/TestCipherKeyWrapperPBEKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/TestCipherPBE.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/TestCipherPBECons.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RC2ArcFour/CipherKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestOAEP.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestOAEPPadding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestOAEPParameterSpec.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestOAEPWithParams.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestOAEP_KAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestRSA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/UTIL/StrongOrUnlimited.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/UTIL/SunJCEGetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/util/jar/JarFile/mrjar/MultiReleaseJarAPI.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/util/jar/JarFile/mrjar/MultiReleaseJarSecurity.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/math/BigInteger/ModPow65537.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestNoPaddingModes.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/KeyWrap/TestGeneral.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/KeyWrap/TestKeySizeCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/TextLength/SameBufferOverwrite.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# DES Cipher related
+
+com/sun/crypto/provider/Cipher/TextLength/TestCipherTextLength.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20KAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20KeyGeneratorTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20NoReuse.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20Poly1305ParamTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/OutputSizeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/unittest/ChaCha20CipherUnitTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# Check all the security providers, including SunJCE, SunRsaSign, etc.
+
+java/lang/SecurityManager/CheckSecurityProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# PKCS11Exception: CKR_ATTRIBUTE_VALUE_INVALID
+
+java/util/jar/JarInputStream/ExtraFileInMetaInf.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# Existing Jars sign related
+
+java/util/jar/JarFile/ScanSignedJar.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/util/jar/JarInputStream/ScanSignedJar.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/util/jar/JarFile/TurkCert.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/util/jar/JarInputStream/TestIndexedJarWithBadSignature.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/util/jar/JarFile/SignedJarFileGetInputStream.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+#
+# Extended.openjdk Failures Exclude List for FIPS Testing
+#
+# KeyStoreException JKS not found
+security/infra/java/security/cert/CertPathValidator/certification/AmazonCA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+security/infra/java/security/cert/CertPathValidator/certification/ComodoCA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+security/infra/java/security/cert/CertPathValidator/certification/EntrustCA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+security/infra/java/security/cert/CertPathValidator/certification/GlobalSignR6CA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+security/infra/java/security/cert/CertPathValidator/certification/GoDaddyCA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+security/infra/java/security/cert/CertPathValidator/certification/LetsEncryptCA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+security/infra/java/security/cert/CertPathValidator/certification/SSLCA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+security/infra/java/security/cert/CertPathValidator/certification/TeliaSoneraCA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# DSA, dsaWithSHA1 related
+java/security/cert/CertificateFactory/openssl/OpenSSLCert.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/cert/CertificateFactory/ReturnStream.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/cert/CertificateFactory/slowstream.sh https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/cert/CertPath/Serialize.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/cert/CertPathEncodingTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/cert/CertPathValidator/nameConstraintsRFC822/ValidateCertPath.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/cert/CertPathValidatorException/Serial.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/cert/PolicyNode/GetPolicyQualifiers.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/cert/X509CertSelectorTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/CodeSigner/Serialize.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/misc/TestDefaultRandom.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SecureClassLoader/DefineClass.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/Signature/Offsets.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/UnresolvedPermission/AccessorMethods.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# SunJGSS and krb5 related
+sun/security/krb5/auto/AcceptorSubKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/AcceptPermissions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/Addresses.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/AddressesAndNameType.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/AlwaysEncPaReq.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/Basic.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/BasicKrb5Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/BasicProc.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/BogusKDC.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/CleanState.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/CrossRealm.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/DiffNameSameKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/DiffSaltParams.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/DupEtypes.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/DynamicKeytab.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/EmptyPassword.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/FileKeyTab.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/ForwardableCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/Forwarded.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/GSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/GSSUnbound.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/HttpNegotiateServer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/HttpsCB.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/IgnoreChannelBinding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/KdcPolicy.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/KeyPermissions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/KeyTabCompat.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/KPEquals.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/KrbTicket.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/KvnoNA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/LifeTimeInSeconds.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/LoginModuleOptions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/LoginNoPass.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/LongLife.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/ModuleName.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/MoreKvno.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/MSOID2.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/NewInquireTypes.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/NewSalt.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/NoAddresses.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/NoInitNoKeytab.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/NonAscii.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/NoneReplayCacheTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/NonMutualSpnego.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/NullRenewUntil.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/OkAsDelegate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/OkAsDelegateXRealm.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/OnlyDesLogin.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/PrincipalNameEquals.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/principalProperty/PrincipalSystemPropTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/ReferralsTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/RefreshKrb5Config.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/Renew.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/Renewal.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/ReplayCacheTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/ReplayCacheTestProc.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/ReplayCacheTestProcWithMD5.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/RRC.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/S4U2proxy.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/S4U2proxyGSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/S4U2self.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/S4U2selfAsServer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/S4U2selfAsServerGSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/S4U2selfGSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/SaslBasic.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/SaslMutual.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/SaslUnbound.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/SPNEGO.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/SpnegoLifeTime.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/SpnegoReqFlags.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/Test5653.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/TicketSName.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/TwoOrThree.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/TwoPrinces.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/TwoTab.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/Unavailable.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/UnboundService.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/UseCacheAndStoreKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/auto/W83.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/etype/KerberosAesSha2.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/etype/WeakCrypto.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/KrbCredSubKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/ktab/BufferBoundary.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/ktab/FileKeyTab.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/ktab/KeyTabIndex.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/RFC396xTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/krb5/runNameEquals.sh.runNameEquals
+sun/security/krb5/ServiceCredsCombination.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/jgss/GssMemoryIssues.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/jgss/spnego/MSOID.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+sun/security/jgss/spnego/NotPreferredMech.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# security.provider.8=XMLDSig related
+javax/xml/crypto/dsig/BadXPointer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/xml/crypto/dsig/ErrorHandlerPermissions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/xml/crypto/dsig/GenerationTests.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/xml/crypto/dsig/GetInstanceTests.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/xml/crypto/dsig/keyinfo/KeyInfo/Marshal.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/xml/crypto/dsig/PSSSpec.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/xml/crypto/dsig/SecureValidation.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/xml/crypto/dsig/SecurityManager/XMLDSigWithSecMgr.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/xml/crypto/dsig/TransformService/NullParent.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/xml/crypto/dsig/ValidationTests.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/xml/crypto/dsig/FileSocketPermissions.java.FileSocketPermissions https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# Related to SunJCE or SunRsaSign, no such provider: SunJCE or no such provider: SunRsaSign
+javax/crypto/Cipher/CipherInputStreamExceptions.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/Cipher/GetMaxAllowed.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/Cipher/TestCipherMode.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/Cipher/TestGetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/CipherSpi/DirectBBRemaining.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/CryptoPermission/AllPermCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/CryptoPermission/LowercasePermCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/CryptoPermission/RC2PermCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/CryptoPermission/RC4AliasPermCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/CryptoPermission/RSANoLimit.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/EncryptedPrivateKeyInfo/GetAlgName.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/EncryptedPrivateKeyInfo/GetKeySpec.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException2.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecInvalidEncoding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/KeyGenerator/TestGetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/Mac/TestGetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/SecretKeyFactory/PBKDF2TranslateTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/SecretKeyFactory/SecKeyFacSunJCEPrf.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/SecretKeyFactory/SecKFTranslateTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/spec/DESKeySpec/CheckParity.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/spec/RC2ParameterSpec/RC2AlgorithmParameters.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/CICO/CICODESFuncTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/CICO/PBEFunc/CICOPBEFuncTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/Encrypt.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/GCMLargeDataKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/GCMParameterSpecTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/KeyWrapper.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/ReadWriteSkip.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/SameBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/SealedObjectTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/WrongAAD.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/CICO.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/CTR.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Padding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4511676.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4512524.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4512704.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4513830.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4517355.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/Test4626070.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestAESCipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestAESCiphers/TestAESWithDefaultProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestAESCiphers/TestAESWithRemoveAddProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestCICOWithGCM.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestCICOWithGCMAndAAD.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestCopySafe.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestGCMKeyAndIvCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestISO10126Padding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestKATForECB_IV.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestKATForECB_VK.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestKATForECB_VT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestKATForGCM.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestNonexpanding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestNoPaddingModes.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestSameBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AES/TestShortBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/Blowfish/BlowfishTestVector.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/Blowfish/TestCipherBlowfish.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/CTR/CounterMode.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/CTS/CTSMode.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/DesAPITest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/DESKeyCleanupTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/DESSecretKeySpec.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/DoFinalReturnLen.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/FlushBug.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/KeyWrapping.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/PaddingTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/Sealtest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/TestCipherDES.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/TestCipherDESede.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/DES/TextPKCS5PaddingTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/KeyWrap/NISTWrapKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/KeyWrap/TestGeneral.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/KeyWrap/TestKeySizeCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/KeyWrap/XMLEncKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/CheckPBEKeySize.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/DecryptWithoutParameters.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/NegativeLength.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBEInvalidParamsTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBEKeyCleanupTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBEKeysAlgorithmNames.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBEKeyTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBEParametersTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBES2Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBESameBuffer/PBESameBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBESealedObject.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBKDF2Translate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBMacBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PBMacDoFinalVsUpdate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PKCS12Cipher.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PKCS12CipherKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/PKCS12Oid.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/TestCipherKeyWrapperPBEKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/TestCipherPBE.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/PBE/TestCipherPBECons.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RC2ArcFour/CipherKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestOAEP.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestOAEP_KAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestOAEPPadding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestOAEPParameterSpec.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestOAEPWithParams.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/RSA/TestRSA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/TextLength/SameBufferOverwrite.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/UTIL/StrongOrUnlimited.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/UTIL/SunJCEGetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/DHGenSharedSecret.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/DHKeyAgreement2.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/DHKeyAgreement3.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/DHKeyFactory.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/DHKeyGenSpeed.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/SameDHKeyStressTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/SupportedDHKeys.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/SupportedDHParamGens.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/SupportedDHParamGensLongKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/TestExponentSize.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyAgreement/UnsupportedDHKeys.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyFactory/PBKDF2HmacSHA1FactoryTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyFactory/TestProviderLeak.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyGenerator/Test4628062.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/KeyGenerator/TestExplicitKeyLength.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/DigestCloneabilityTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/EmptyByteBufferTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/HmacMD5.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/HmacPBESHA1.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/HmacSaltLengths.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/HmacSHA512.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/LargeByteBufferTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/MacClone.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/MacKAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/MacSameTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Mac/NullByteBufferTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/NSASuiteB/TestAESOids.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/NSASuiteB/TestAESWrapOids.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/NSASuiteB/TestHmacSHAOids.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/TLS/TestKeyMaterial.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/TLS/TestLeadingZeroes.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/TLS/TestMasterSecret.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/TLS/TestPremaster.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/TLS/TestPRF.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/TLS/TestPRF12.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyAgreement/KeySizeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyAgreement/KeySpecTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyAgreement/MultiThreadTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyAgreement/NegativeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyFactory/GenerateRSAPrivateCrtKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyFactory/KeyFactoryGetKeySpecForInvalidSpec.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyPairGenerator/GenerateRSAKeyPair.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/TestKeyStoreEntry.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/Security/ClassLoaderDeadlock/Deadlock.sh.Deadlock
+java/security/Signature/NONEwithRSA.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/Signature/SignatureGetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/spec/PKCS8EncodedKeySpec/Algorithm.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# CHACHA20 related
+com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20KAT.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20KeyGeneratorTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20NoReuse.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20Poly1305ParamTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/OutputSizeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/ChaCha20/unittest/ChaCha20CipherUnitTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# java.security.NoSuchAlgorithmException: Cannot find any provider supporting Blowfish
+javax/crypto/Cipher/Turkish.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# Generated DES key, java.lang.NullPointerException. Or for DES/DESede ciphers
+com/sun/crypto/provider/Cipher/TextLength/TestCipherTextLength.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/CICO/CICOSkipTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# FIPS not support SunJCE provider
+javax/crypto/Mac/ByteBuffers.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+javax/crypto/Cipher/ByteBuffers.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# RSASSA-PSS KeyPairGenerator not available
+java/security/cert/X509Certificate/GetSigAlgParams.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# LDAP CertStore not available
+java/security/cert/GetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# Removed algorithms from Sun related
+java/security/KeyPairGenerator/Failover.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/MessageDigest/ByteBuffers.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/MessageDigest/TestDigestIOStream.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/MessageDigest/TestSameLength.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/MessageDigest/TestSameValue.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/Provider/SupportsParameter.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/Security/CaseInsensitiveAlgNames.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/Signature/ByteBuffers.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/Signature/TestInitSignWithMyOwnRandom.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SignedObject/Copy.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# DSA related
+java/security/SignedObject/Chain.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# P11Signature Unknown mechanism
+java/security/Provider/NewInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# Related to com.sun.exp.provider.EXP
+java/security/Security/signedfirst/Static.sh.Static
+java/security/Security/signedfirst/Dyn.sh.Dyn
+
+# SHA1PRNG and DRBG SecureRandom not available
+java/security/SecureRandom/ApiTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SecureRandom/DefaultAlgo.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SecureRandom/DefaultProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SecureRandom/EnoughSeedTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SecureRandom/GetAlgorithm.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SecureRandom/GetInstanceTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SecureRandom/MultiThreadTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SecureRandom/NoSync.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SecureRandom/Serialize.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/SecureRandom/SerializedSeedTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# JKS KeyStore not available
+java/security/KeyStore/CheckInputStream.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/EntryMethods.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/KeyStoreBuilder.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/PBETest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/ProbeKeystores.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/TestKeyStoreBasic.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/Policy/SignedJar/SignedJarTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# PKCS12 Key related
+java/security/cert/CertPathValidator/OCSP/GetAndPostTests.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/PKCS12/CheckDefaults.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/PKCS12/ConvertP12Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/PKCS12/EntryProtectionTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/PKCS12/MetadataEmptyTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/PKCS12/MetadataStoreLoadTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/PKCS12/ReadP12Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/PKCS12/StoreTrustedCertAPITest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/PKCS12/StoreTrustedCertKeytool.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyStore/PKCS12/WriteP12Test.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# DSA PKCS8 related
+java/security/KeyRep/SerialDSAPubKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/KeyRep/SerialOld.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# Related to curves X25519
+java/security/KeyAgreement/KeyAgreementTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# No cipher suites in common
+com/sun/jndi/ldap/LdapCBPropertiesTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# DES and DESEDE related
+javax/crypto/KeyGenerator/TestKGParity.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# Related to exist testing jar
+java/security/Provider/SecurityProviderModularTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# AES-GCM is a non-Approved mode in FIPS mode
+com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/GCMShortBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+com/sun/crypto/provider/Cipher/AEAD/OverlapByteBuffer.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# MessageDigest, Signature Engines are not supported in FIPS mode
+java/security/MessageDigest/TestCloneable.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+java/security/Signature/TestCloneable.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# Related to HmacSHA3-224
+javax/crypto/KeyGenerator/CompareKeys.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64
+
+# Related to CKR_ENCRYPTED_DATA_LEN_RANGE.
+# The PKCS11 spec defined this ciphertext input check.
+# If the ciphertext input is not a multiple of block size during the Cipher.DECRYPT_MODE, the CKR_ENCRYPTED_DATA_LEN_RANGE will return.
+# PKCS11 spec link https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/os/pkcs11-base-v3.0-os.html
+javax/crypto/CipherSpi/ResetByteBuffer.java.ResetByteBuffer https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/116 linux-x64


### PR DESCRIPTION
Cherry pick https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/134 and the latest FIPS excludes for 0.33