### PR TITLE
Add initCompressionFlag() to String constructors

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -525,6 +525,7 @@ public final class String
                 this.value = val;
                 return;
             }
+            initCompressionFlag();
         }
         this.coder = UTF16;
         this.value = StringUTF16.toBytes(codePoints, offset, count);
@@ -589,6 +590,9 @@ public final class String
             }
             this.value = val;
             this.coder = UTF16;
+            if (COMPACT_STRINGS) {
+                initCompressionFlag();
+            }
         }
     }
 
@@ -822,6 +826,7 @@ public final class String
                         coder = LATIN1;
                         return;
                     }
+                    initCompressionFlag();
                 }
                 coder = UTF16;
                 value = StringUTF16.toBytes(ca, 0, clen);
@@ -850,6 +855,9 @@ public final class String
             }
             coder = UTF16;
             value = StringUTF16.toBytes(ca, 0, caLen);
+        }
+        if (COMPACT_STRINGS && coder == UTF16) {
+            initCompressionFlag();
         }
     }
 
@@ -5262,7 +5270,8 @@ public final class String
                 this.coder = LATIN1;
                 return;
             }
-        }
+            initCompressionFlag();
+		}
         this.coder = UTF16;
         this.value = StringUTF16.toBytes(value, off, len);
     }
@@ -5285,6 +5294,7 @@ public final class String
                     this.value = buf;
                     return;
                 }
+                initCompressionFlag();
             }
             this.coder = UTF16;
             this.value = Arrays.copyOfRange(val, 0, length << 1);


### PR DESCRIPTION
Set compression flag in constructors creating uncompressed strings when compact strings is enabled. OpenJ9 uses this flag to check if a string with uncompressed characters has been created, and not having it enabled when there has been leads to errors since the code assumes all strings are still compressed.

An example would be the following code segment comparing equality:
```Java
String a = Character.toString(64392); // bytes 0x88 0xfb in little endian
String b = Character.toString(1672); // bytes 0x88 0x06 in little endian
a.equals(b);
```
With compact strings enabled and without this change, the equals check would return true because it would only check the first byte since it assumes the string is compressed.