### PR TITLE
Avoid non-portable uses of date utility

### DIFF
--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+# ===========================================================================
+
 ################################################################################
 # This file contains helper functions for Init.gmk.
 # It is divided in two parts, depending on if a SPEC is present or not
@@ -310,18 +314,10 @@ else # $(HAS_SPEC)=true
   # level of reproducible builds
   define SetupReproducibleBuild
     ifeq ($$(SOURCE_DATE), updated)
-      SOURCE_DATE := $$(shell $$(DATE) +"%s")
+      SOURCE_DATE := $$(shell $$(JAVA) $$(TOPDIR)/make/src/classes/DateUtil.java)
     endif
     export SOURCE_DATE_EPOCH := $$(SOURCE_DATE)
-    ifeq ($$(IS_GNU_DATE), yes)
-      export SOURCE_DATE_ISO_8601 := $$(shell $$(DATE) --utc \
-                                                       --date="@$$(SOURCE_DATE_EPOCH)" \
-                                                       +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
-    else
-      export SOURCE_DATE_ISO_8601 := $$(shell $$(DATE) -u \
-                                                       -j -f "%s" "$$(SOURCE_DATE_EPOCH)" \
-                                                       +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
-    endif
+    export SOURCE_DATE_ISO_8601 := $$(shell $$(JAVA) $$(TOPDIR)/make/src/classes/DateUtil.java --date="$$(SOURCE_DATE_EPOCH)" --format="yyyy-MM-dd'T'HH:mm:ss'Z'")
   endef
 
   # Parse COMPARE_BUILD into COMPARE_BUILD_*

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+# ===========================================================================
+
 ###############################################################################
 # Check which variant of the JDK that we want to build.
 # Currently we have:
@@ -217,13 +221,9 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
   elif test "x$with_copyright_year" != x; then
     COPYRIGHT_YEAR="$with_copyright_year"
   elif test "x$SOURCE_DATE_EPOCH" != x; then
-    if test "x$IS_GNU_DATE" = xyes; then
-      COPYRIGHT_YEAR=`date --date=@$SOURCE_DATE_EPOCH +%Y`
-    else
-      COPYRIGHT_YEAR=`date -j -f %s $SOURCE_DATE_EPOCH +%Y`
-    fi
+    COPYRIGHT_YEAR=`$JAVA $TOPDIR/make/src/classes/DateUtil.java --format=yyyy --date="$SOURCE_DATE_EPOCH"`
   else
-    COPYRIGHT_YEAR=`$DATE +'%Y'`
+    COPYRIGHT_YEAR=`$JAVA $TOPDIR/make/src/classes/DateUtil.java --format=yyyy`
   fi
   AC_SUBST(COPYRIGHT_YEAR)
 
@@ -675,7 +675,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_REPRODUCIBLE_BUILD],
     AC_MSG_RESULT([determined at build time, from 'updated'])
   elif test "x$with_source_date" = xcurrent; then
     # Set the current time
-    SOURCE_DATE=$($DATE +"%s")
+    SOURCE_DATE=$($JAVA $TOPDIR/make/src/classes/DateUtil.java)
     AC_MSG_RESULT([$SOURCE_DATE, from 'current'])
   elif test "x$with_source_date" = xversion; then
     # Use the date from version-numbers.conf

--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+# ===========================================================================
+
 m4_include([util_paths.m4])
 
 ###############################################################################
@@ -236,19 +240,7 @@ AC_DEFUN([UTIL_GET_MATCHING_VALUES],
 # $2: input date/time string
 AC_DEFUN([UTIL_GET_EPOCH_TIMESTAMP],
 [
-  if test "x$IS_GNU_DATE" = xyes; then
-    # GNU date
-    timestamp=$($DATE --utc --date=$2 +"%s" 2> /dev/null)
-  else
-    # BSD date
-    timestamp=$($DATE -u -j -f "%F %T" "$2" "+%s" 2> /dev/null)
-    if test "x$timestamp" = x; then
-      # Perhaps the time was missing
-      timestamp=$($DATE -u -j -f "%F %T" "$2 00:00:00" "+%s" 2> /dev/null)
-      # If this did not work, we give up and return the empty string
-    fi
-  fi
-  $1=$timestamp
+  $1=$($JAVA $TOPDIR/make/src/classes/DateUtil.java --date="$2")
 ])
 
 ###############################################################################

--- a/make/src/classes/DateUtil.java
+++ b/make/src/classes/DateUtil.java
@@ -1,0 +1,94 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ * ===========================================================================
+ */
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+
+public class DateUtil {
+
+    public static void main(String... args) {
+        String date = "";
+        String format = "";
+
+        for (String arg : args) {
+            if (arg.startsWith("--date=")) {
+                date = arg.substring(7).trim();
+            } else if (arg.startsWith("--format=")) {
+                format = arg.substring(9).trim();
+            } else {
+                showUsageAndExit();
+            }
+        }
+
+        LocalDateTime time = parseTime(date);
+
+        if (format.isEmpty()) {
+            System.out.println(time.toEpochSecond(ZoneOffset.UTC));
+        } else {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format, Locale.ROOT);
+
+            System.out.println(formatter.format(time));
+        }
+    }
+
+    private static LocalDateTime parseTime(String text) {
+        if (text.isEmpty()) {
+            return LocalDateTime.now(ZoneOffset.UTC);
+        }
+
+        if (text.matches("\\d+")) {
+            return LocalDateTime.ofEpochSecond(Long.parseLong(text), 0, ZoneOffset.UTC);
+        }
+
+        try {
+            return LocalDateTime.ofInstant(Instant.parse(text), ZoneOffset.UTC);
+        } catch (DateTimeParseException e) {
+            // try next format
+        }
+
+        try {
+            return LocalDateTime.parse(text);
+        } catch (DateTimeParseException e) {
+            // try next format
+        }
+
+        try {
+            return LocalDate.parse(text).atStartOfDay();
+        } catch (DateTimeParseException e) {
+            System.err.format("Cannot parse time: '%s'%n", text);
+            System.exit(1);
+            return null;
+        }
+    }
+
+    private static void showUsageAndExit() {
+        System.err.println("Usage: DateUtil [options]");
+        System.err.println("  --date=<time>      time in epoch seconds, or in iso-8601 or yyyy-MM-dd format");
+        System.err.println("  --format=<format>  output format");
+        System.exit(1);
+    }
+
+}


### PR DESCRIPTION
On some platforms, the `date` utility doesn't support the `%s` format specifier or supports neither the `-f` option nor the `-j` option. Use the boot jdk to run a java program instead.