### PR TITLE
Lazily initialize native crypto libraries

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -45,6 +45,8 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/Timer.java \
 		src/java.base/share/classes/java/util/TimerTask.java \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
+		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
+		src/java.base/share/classes/sun/security/jca/ProviderList.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
 	))
 

--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,10 @@ import jdk.internal.reflect.CallerSensitive;
 
 import sun.security.action.GetPropertyAction;
 
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.InternalCRIUSupport;
+/*[ENDIF] CRIU_SUPPORT */
+
 public class NativeCrypto {
 
     /* Define constants for the native digest algorithm indices. */
@@ -52,35 +56,69 @@ public class NativeCrypto {
     private static final boolean traceEnabled = Boolean.parseBoolean(
             GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace", "false"));
 
+    private static final class InstanceHolder {
+        private static final NativeCrypto instance = new NativeCrypto();
+    }
+
     //ossl_vers:
     // -1 : library load failed
     //  0 : openssl 1.0.x
     //  1 : openssl 1.1.x or newer
-    private static final int ossl_ver = AccessController.doPrivileged(
-            (PrivilegedAction<Integer>) () -> {
-                int ossl_ver;
+    private final int ossl_ver;
 
-                try {
-                    System.loadLibrary("jncrypto"); // check for native library
-                    // load OpenSSL crypto library dynamically.
-                    ossl_ver = loadCrypto(traceEnabled);
-                } catch (UnsatisfiedLinkError usle) {
-                    if (traceEnabled) {
-                        System.err.println("UnsatisfiedLinkError: Failure attempting to load jncrypto JNI library");
-                    }
-                    // signal load failure
-                    ossl_ver = -1;
-                }
+    private static int loadCryptoLibraries() {
+        int osslVersion;
 
-                return ossl_ver;
-            }).intValue();
-
-    public static final boolean isLoaded() {
-        return ossl_ver != -1;
+        try {
+            // load jncrypto JNI library
+            System.loadLibrary("jncrypto");
+            // load OpenSSL crypto library dynamically
+            osslVersion = loadCrypto(traceEnabled);
+            if (traceEnabled && (osslVersion != -1)) {
+                System.err.println("Native crypto library load succeeded - using native crypto library.");
+            }
+        } catch (UnsatisfiedLinkError usle) {
+            if (traceEnabled) {
+                System.err.println("UnsatisfiedLinkError: Failure attempting to load jncrypto JNI library");
+                System.err.println("Warning: Native crypto library load failed." +
+                        " Using Java crypto implementation.");
+            }
+            // signal load failure
+            osslVersion = -1;
+        }
+        return osslVersion;
     }
 
-    public static final int getVersion() {
-        return ossl_ver;
+    @SuppressWarnings("removal")
+    private NativeCrypto() {
+        ossl_ver = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> loadCryptoLibraries()).intValue();
+    }
+
+    /**
+     * Check whether the native crypto libraries are loaded successfully.
+     * If CRIU is enabled and a checkpoint is allowed, the library loading
+     * is disallowed, and this returns false.
+     *
+     * @return whether the native crypto libraries have been loaded successfully
+     */
+    public static final boolean isAllowedAndLoaded() {
+        return getVersionIfAvailable() >= 0;
+    }
+
+    /**
+     * Return the OpenSSL version.
+     * -1 is returned if CRIU is enabled and the checkpoint is allowed.
+     * The libraries are to be loaded for the first reference of InstanceHolder.instance.
+     *
+     * @return the OpenSSL library version if it is available
+     */
+    public static final int getVersionIfAvailable() {
+/*[IF CRIU_SUPPORT]*/
+        if (InternalCRIUSupport.isCheckpointAllowed()) {
+            return -1;
+        }
+/*[ENDIF] CRIU_SUPPORT */
+        return InstanceHolder.instance.ossl_ver;
     }
 
     /**
@@ -98,62 +136,19 @@ public class NativeCrypto {
      * @return whether the given native crypto algorithm is enabled
      */
     public static final boolean isAlgorithmEnabled(String property, String name) {
-        return isAlgorithmEnabled(property, name, true, null);
-    }
-
-    /**
-     * Check whether native crypto is enabled. Note that, by default, native
-     * crypto is enabled (the native crypto library implementation is used).
-     *
-     * The property 'jdk.nativeCrypto' is used to control enablement of all
-     * native cryptos (Digest, CBC, GCM, RSA, ChaCha20, EC, and PBE), while
-     * the given property should be used to control enablement of the given
-     * native crypto algorithm.
-     *
-     * This method is used for native cryptos that have additional requirements
-     * in order to load.
-     *
-     * @param property the property used to control enablement of the given
-     *                 algorithm
-     * @param name the name of the class or the algorithm
-     * @param satisfied whether the additional requirements are met
-     * @param explanation explanation if the native crypto is not loaded
-     *                    due to the additional requirements not being met
-     * @return whether the given native crypto algorithm is enabled
-     */
-    public static final boolean isAlgorithmEnabled(String property, String name, boolean satisfied, String explanation) {
         boolean useNativeAlgorithm = false;
         if (useNativeCrypto) {
             useNativeAlgorithm = Boolean.parseBoolean(
                     GetPropertyAction.privilegedGetProperty(property, "true"));
         }
-        if (useNativeAlgorithm) {
-            /*
-             * User wants to use the native crypto implementation. Ensure that the
-             * native crypto library is loaded successfully. Otherwise, issue a warning
-             * message and fall back to the built-in java crypto implementation.
-             */
-            if (isLoaded()) {
-                if (satisfied) {
-                    if (traceEnabled) {
-                        System.err.println(name + " - using native crypto library.");
-                    }
-                } else {
-                    useNativeAlgorithm = false;
-                    if (traceEnabled) {
-                        System.err.println("Warning: " + name + " native requirements not satisfied. " +
-                                explanation + " Using Java crypto implementation.");
-                    }
-                }
+        /*
+         * User wants to use the native crypto implementation. Ensure that the native crypto library is enabled.
+         * Otherwise, issue a warning message.
+         */
+        if (traceEnabled) {
+            if (useNativeAlgorithm) {
+                System.err.println(name + " native crypto implementation enabled.");
             } else {
-                useNativeAlgorithm = false;
-                if (traceEnabled) {
-                    System.err.println("Warning: Native crypto library load failed." +
-                            " Using Java crypto implementation.");
-                }
-            }
-        } else {
-            if (traceEnabled) {
                 System.err.println(name + " native crypto implementation disabled." +
                         " Using Java crypto implementation.");
             }
@@ -169,16 +164,12 @@ public class NativeCrypto {
         return traceEnabled;
     }
 
-    private NativeCrypto() {
-        // empty
-    }
-
     @CallerSensitive
     public static NativeCrypto getNativeCrypto() {
         ClassLoader callerClassLoader = Reflection.getCallerClass().getClassLoader();
 
         if ((callerClassLoader == null) || (callerClassLoader == VM.getVMLangAccess().getExtClassLoader())) {
-            return new NativeCrypto();
+            return InstanceHolder.instance;
         }
 
         throw new SecurityException("NativeCrypto");

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -183,7 +183,7 @@ final class CipherCore {
              * Check whether native CBC is enabled and instantiate
              * the NativeCipherBlockChaining class.
              */
-            if (useNativeCBC && blockSize == 16) {
+            if (useNativeCBC && (blockSize == 16) && NativeCrypto.isAllowedAndLoaded()) {
                 cipher = new NativeCipherBlockChaining(rawImpl);
             } else {
                 cipher = new CipherBlockChaining(rawImpl);

--- a/src/java.base/share/classes/com/sun/crypto/provider/PKCS12PBECipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/PKCS12PBECipherCore.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -64,7 +64,7 @@ final class PKCS12PBECipherCore {
 
     private static final int DEFAULT_SALT_LENGTH = 20;
     private static final int DEFAULT_COUNT = 1024;
-    private static final NativeCrypto nativeCrypto = NativeCrypto.getNativeCrypto();
+    private static NativeCrypto nativeCrypto;
     private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
     /* The property 'jdk.nativePBE' is used to control enablement of the native
      * PBE implementation.
@@ -102,7 +102,7 @@ final class PKCS12PBECipherCore {
         }
         byte[] key = new byte[n];
 
-        if (useNativePBE) {
+        if (useNativePBE && NativeCrypto.isAllowedAndLoaded()) {
             boolean hashSupported = true;
             int hashIndex = 0;
             if (hashAlgo.equals("SHA") || hashAlgo.equals("SHA1") || hashAlgo.equals("SHA-1")) {
@@ -119,6 +119,9 @@ final class PKCS12PBECipherCore {
                 hashSupported = false;
             }
             if (hashSupported) {
+                if (nativeCrypto == null) {
+                    nativeCrypto = NativeCrypto.getNativeCrypto();
+                }
                 if (nativeCrypto.PBEDerive(passwd, passwd.length, salt, salt.length, key, ic, n, type, hashIndex) != -1) {
                     return key;
                 } else if (nativeCryptTrace) {

--- a/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -90,8 +90,7 @@ public final class SunJCE extends Provider {
     /* The property 'jdk.nativeChaCha20' is used to control enablement of the native
      * ChaCha20 implementation. ChaCha20 is only supported in OpenSSL 1.1.0 and above.
      */
-    private static final boolean useNativeChaCha20Cipher = NativeCrypto.isAlgorithmEnabled("jdk.nativeChaCha20",
-            "NativeChaCha20Cipher", NativeCrypto.getVersion() >= 1, "Need OpenSSL 1.1.0 or above for ChaCha20 support.");
+    private static final boolean useNativeChaCha20Cipher = NativeCrypto.isAlgorithmEnabled("jdk.nativeChaCha20", "NativeChaCha20Cipher");
 
     /* The property 'jdk.nativeGCM' is used to control enablement of the native
      * GCM implementation.
@@ -292,7 +291,7 @@ public final class SunJCE extends Provider {
         attrs.put("SupportedModes", "GCM");
         attrs.put("SupportedKeyFormats", "RAW");
 
-        if (useNativeGaloisCounterMode) {
+        if (useNativeGaloisCounterMode && NativeCrypto.isAllowedAndLoaded()) {
             ps("Cipher", "AES/GCM/NoPadding",
                     "com.sun.crypto.provider.NativeGaloisCounterMode$AESGCM", null,
                     attrs);
@@ -337,7 +336,7 @@ public final class SunJCE extends Provider {
         attrs.clear();
         attrs.put("SupportedKeyFormats", "RAW");
 
-        if (useNativeChaCha20Cipher) {
+        if (useNativeChaCha20Cipher && (NativeCrypto.getVersionIfAvailable() >= 1)) {
             ps("Cipher", "ChaCha20",
                     "com.sun.crypto.provider.NativeChaCha20Cipher$ChaCha20Only",
                     null, attrs);

--- a/src/java.base/share/classes/sun/security/jca/ProviderConfig.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderConfig.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.jca;
 
 import java.io.File;
@@ -314,6 +320,12 @@ final class ProviderConfig {
             }
         });
     }
+
+/*[IF CRIU_SUPPORT]*/
+    static void reloadServices() {
+        ProviderLoader.INSTANCE.services.reload();
+    }
+/*[ENDIF] CRIU_SUPPORT */
 
     // Inner class for loading security providers listed in java.security file
     private static final class ProviderLoader {

--- a/src/java.base/share/classes/sun/security/jca/ProviderList.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderList.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.jca;
 
 import java.util.*;
@@ -93,6 +99,10 @@ public final class ProviderList {
         return AccessController.doPrivileged(
                         new PrivilegedAction<ProviderList>() {
             public ProviderList run() {
+/*[IF CRIU_SUPPORT]*/
+                // ensure the providers are reloaded from scratch
+                ProviderConfig.reloadServices();
+/*[ENDIF] CRIU_SUPPORT */
                 return new ProviderList();
             }
         });

--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -278,7 +278,7 @@ public final class SunEntries {
          * Set the digest provider based on whether native crypto is
          * enabled or not.
          */
-        if (useNativeDigest) {
+        if (useNativeDigest && NativeCrypto.isAllowedAndLoaded()) {
             providerSHA = "sun.security.provider.NativeSHA";
             providerSHA224 = "sun.security.provider.NativeSHA2$SHA224";
             providerSHA256 = "sun.security.provider.NativeSHA2$SHA256";

--- a/src/java.base/share/classes/sun/security/rsa/RSACore.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSACore.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -117,8 +117,8 @@ public final class RSACore {
      */
     public static byte[] rsa(byte[] msg, RSAPublicKey key)
             throws BadPaddingException {
-        if (useNativeRsa && key instanceof sun.security.rsa.RSAPublicKeyImpl) {
-            byte[] ret = NativeRSACore.rsa(msg, (sun.security.rsa.RSAPublicKeyImpl) key);
+        if (useNativeRsa && key instanceof sun.security.rsa.RSAPublicKeyImpl rsaKey && NativeCrypto.isAllowedAndLoaded()) {
+            byte[] ret = NativeRSACore.rsa(msg, rsaKey);
             if (ret != null) {
                 return ret;
             }
@@ -146,8 +146,8 @@ public final class RSACore {
     public static byte[] rsa(byte[] msg, RSAPrivateKey key, boolean verify)
             throws BadPaddingException {
         if (key instanceof RSAPrivateCrtKey) {
-            if (useNativeRsa && key instanceof sun.security.rsa.RSAPrivateCrtKeyImpl) {
-                byte[] ret = NativeRSACore.rsa(msg, (sun.security.rsa.RSAPrivateCrtKeyImpl) key, verify);
+            if (useNativeRsa && key instanceof sun.security.rsa.RSAPrivateCrtKeyImpl rsaKey && NativeCrypto.isAllowedAndLoaded()) {
+                byte[] ret = NativeRSACore.rsa(msg, rsaKey, verify);
                 if (ret != null) {
                     return ret;
                 }

--- a/src/java.base/share/classes/sun/security/rsa/RSAPrivateCrtKeyImpl.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPrivateCrtKeyImpl.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -84,10 +84,6 @@ public final class RSAPrivateCrtKeyImpl
     private transient AlgorithmParameterSpec keyParams;
 
     private static NativeCrypto nativeCrypto;
-
-    static {
-        nativeCrypto = NativeCrypto.getNativeCrypto();
-    }
 
     /**
      * Generate a new RSAPrivate(Crt)Key from the specified type,
@@ -335,6 +331,9 @@ public final class RSAPrivateCrtKeyImpl
         byte[] dQ_2c   = dQ.toByteArray();
         byte[] qInv_2c = qInv.toByteArray();
 
+        if (nativeCrypto == null) {
+            nativeCrypto = NativeCrypto.getNativeCrypto();
+        }
         return nativeCrypto.createRSAPrivateCrtKey(n_2c, n_2c.length, d_2c, d_2c.length, e_2c, e_2c.length,
                 p_2c, p_2c.length, q_2c, q_2c.length,
                 dP_2c, dP_2c.length, dQ_2c, dQ_2c.length, qInv_2c, qInv_2c.length);
@@ -354,9 +353,11 @@ public final class RSAPrivateCrtKeyImpl
 
     @Override
     public void finalize() {
-        Long itr;
-        while ((itr = keyQ.poll()) != null) {
-            nativeCrypto.destroyRSAKey(itr);
+        if (nativeCrypto != null) {
+            Long itr;
+            while ((itr = keyQ.poll()) != null) {
+                nativeCrypto.destroyRSAKey(itr);
+            }
         }
     }
 

--- a/src/java.base/share/classes/sun/security/rsa/RSAPublicKeyImpl.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPublicKeyImpl.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -75,10 +75,6 @@ public final class RSAPublicKeyImpl extends X509Key implements RSAPublicKey {
     private transient AlgorithmParameterSpec keyParams;
 
     private static NativeCrypto nativeCrypto;
-
-    static {
-        nativeCrypto = nativeCrypto.getNativeCrypto();
-    }
 
     /**
      * Generate a new RSAPublicKey from the specified type, format, and
@@ -267,6 +263,9 @@ public final class RSAPublicKeyImpl extends X509Key implements RSAPublicKey {
         byte[] n_2c = n.toByteArray();
         byte[] e_2c = e.toByteArray();
 
+        if (nativeCrypto == null) {
+            nativeCrypto = NativeCrypto.getNativeCrypto();
+        }
         return nativeCrypto.createRSAPublicKey(n_2c, n_2c.length, e_2c, e_2c.length);
     }
 
@@ -284,9 +283,11 @@ public final class RSAPublicKeyImpl extends X509Key implements RSAPublicKey {
 
     @Override
     public void finalize() {
-        Long itr;
-        while ((itr = keyQ.poll()) != null) {
-            nativeCrypto.destroyRSAKey(itr);
+        if (nativeCrypto != null) {
+            Long itr;
+            while ((itr = keyQ.poll()) != null) {
+                nativeCrypto.destroyRSAKey(itr);
+            }
         }
     }
 }

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPrivateKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPrivateKeyImpl.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -71,7 +71,7 @@ import sun.security.pkcs.PKCS8Key;
 public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
 
     private static final long serialVersionUID = 88695385615075129L;
-    private static final NativeCrypto nativeCrypto = NativeCrypto.getNativeCrypto();
+    private static NativeCrypto nativeCrypto;
 
     private BigInteger s;       // private value
     private byte[] arrayS;      // private value as a little-endian array
@@ -242,6 +242,9 @@ public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
                     byte[] n = this.params.getOrder().toByteArray();
                     byte[] h = BigInteger.valueOf(this.params.getCofactor()).toByteArray();
                     long nativePointer;
+                    if (nativeCrypto == null) {
+                        nativeCrypto = NativeCrypto.getNativeCrypto();
+                    }
                     if (field instanceof ECFieldFp) {
                         byte[] p = ((ECFieldFp)field).getP().toByteArray();
                         nativePointer = nativeCrypto.ECEncodeGFp(a, a.length, b, b.length, p, p.length, gx, gx.length, gy, gy.length, n, n.length, h, h.length);

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPublicKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPublicKeyImpl.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -54,7 +54,7 @@ import sun.security.x509.*;
 public final class ECPublicKeyImpl extends X509Key implements ECPublicKey {
 
     private static final long serialVersionUID = -2462037275160462289L;
-    private static final NativeCrypto nativeCrypto = NativeCrypto.getNativeCrypto();
+    private static NativeCrypto nativeCrypto;
 
     private ECPoint w;
     private ECParameterSpec params;
@@ -167,6 +167,9 @@ public final class ECPublicKeyImpl extends X509Key implements ECPublicKey {
                     byte[] h = BigInteger.valueOf(this.params.getCofactor()).toByteArray();
                     long nativePointer;
                     int fieldType = 0;
+                    if (nativeCrypto == null) {
+                        nativeCrypto = NativeCrypto.getNativeCrypto();
+                    }
                     if (field instanceof ECFieldFp) {
                         byte[] p = ((ECFieldFp)field).getP().toByteArray();
                         nativePointer = nativeCrypto.ECEncodeGFp(a, a.length, b, b.length, p, p.length, gx, gx.length, gy, gy.length, n, n.length, h, h.length);

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -182,7 +182,7 @@ public final class SunEC extends Provider {
                     }
                 } else  if (type.equals("KeyAgreement")) {
                     if (algo.equals("ECDH")) {
-                        if (useNativeEC) {
+                        if (useNativeEC && NativeCrypto.isAllowedAndLoaded()) {
                             return new NativeECDHKeyAgreement();
                         } else {
                             return new ECDHKeyAgreement();
@@ -348,7 +348,7 @@ public final class SunEC extends Provider {
         /*
          * Key Agreement engine
          */
-        if (useNativeEC) {
+        if (useNativeEC && NativeCrypto.isAllowedAndLoaded()) {
             putService(new ProviderService(this, "KeyAgreement",
                 "ECDH", "sun.security.ec.NativeECDHKeyAgreement", null, ATTRS));
         } else {


### PR DESCRIPTION
Delay native crypto library loading to avoid early initialization which might cause CRIU cross architectures restore error; 
Skip native library loading before taking a checkpoint;
Reload the providers from scratch;
Create a singleton NativeCrypto instance.

fix https://github.com/OpenLiberty/open-liberty/issues/23360

Signed-off-by: Jason Feng <fengj@ca.ibm.com>