### PR TITLE
[FFI/VaList] Replace C_LONG with C_LONG_LONG for the type check on Power & zLinux

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/ppc64/TypeClass.java
@@ -53,10 +53,6 @@ public enum TypeClass {
 	POINTER,
 	STRUCT;
 
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
-	private static ValueLayout longLayout = osName.contains("aix") ? C_LONG_LONG : C_LONG;
-
 	public static VarHandle classifyVarHandle(ValueLayout layout) {
 		VarHandle argHandle = null;
 		Class<?> carrier = classifyCarrier(layout);
@@ -69,7 +65,7 @@ public enum TypeClass {
 			|| (carrier == int.class)
 			|| (carrier == long.class)
 		) {
-			argHandle = SharedUtils.vhPrimitiveOrAddress(long.class, longLayout);
+			argHandle = SharedUtils.vhPrimitiveOrAddress(long.class, C_LONG_LONG);
 		} else if (carrier == float.class) {
 			argHandle = SharedUtils.vhPrimitiveOrAddress(double.class, C_DOUBLE);
 		} else if ((carrier == double.class)

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/s390x/sysv/TypeClass.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/abi/s390x/sysv/TypeClass.java
@@ -95,7 +95,7 @@ enum TypeClass {
 			|| (carrier == int.class)
 			|| (carrier == long.class)
 		) {
-			argHandle = SharedUtils.vhPrimitiveOrAddress(long.class, C_LONG);
+			argHandle = SharedUtils.vhPrimitiveOrAddress(long.class, C_LONG_LONG);
 		} else if ((carrier == float.class)
 			|| (carrier == double.class)
 		) {


### PR DESCRIPTION
The changes replace C_LONG(32bit on AIX & Win and 64bit on other platforms) with C_LONG_LONG(64bit on all supported platforms) for the long type to have the type check passed in VaListTest on AIX and Windows.

Fixes: #eclipse-openj9/openj9/issues/16407

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>