### PR TITLE
Fix the alignment issue with long & pointer on AIX

### DIFF
--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -496,7 +496,7 @@ public class PlatformLayouts {
         /**
          * The {@code long long} native type.
          */
-        public static final ValueLayout C_LONG_LONG = ofLongLong(BIG_ENDIAN, 64).withBitAlignment(32);
+        public static final ValueLayout C_LONG_LONG = ofLongLong(BIG_ENDIAN, 64).withBitAlignment(64);
 
         /**
          * The {@code float} native type.
@@ -511,7 +511,7 @@ public class PlatformLayouts {
         /**
          * The {@code T*} native type.
          */
-        public static final ValueLayout C_POINTER = ofPointer(BIG_ENDIAN, 64).withBitAlignment(32);
+        public static final ValueLayout C_POINTER = ofPointer(BIG_ENDIAN, 64).withBitAlignment(64);
 
         /**
          * The {@code va_list} native type, as it is passed to a function.


### PR DESCRIPTION
The changes aim to restore the original alignment setting for long and pointer on AIX given the padding is required in native in the case of struct [int/float,long] and [int/float,pointer].

Fixes: #eclipse-openj9/openj9/issues/16409

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>