### PR TITLE
Update code-signing on macOS

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -131,12 +131,26 @@ endif
 # Usage: $(call CodesignFile, files ...)
 ifeq (,$(CODESIGN))
   CodesignFile =
+else ifeq (debug, $(MACOSX_CODESIGN_MODE))
+  define CodesignFile
+	$(CODESIGN) --remove-signature $1
+	$(CODESIGN) --sign - \
+		--entitlements $(TOPDIR)/make/data/macosxsigning/default-debug.plist \
+		--force \
+		$1
+  endef
+else ifeq (hardened, $(MACOSX_CODESIGN_MODE))
+  define CodesignFile
+	$(CODESIGN) --remove-signature $1
+	$(CODESIGN) --sign "$(MACOSX_CODESIGN_IDENTITY)" \
+		--entitlements $(TOPDIR)/make/data/macosxsigning/default.plist \
+		--force \
+		--options runtime \
+		--timestamp \
+		$1
+  endef
 else
-  CodesignFile = $(CODESIGN) --sign "$(MACOSX_CODESIGN_IDENTITY)" \
-	--entitlements $(TOPDIR)/make/data/macosxsigning/default.plist \
-	--options runtime \
-	--timestamp \
-	$1
+  CodesignFile =
 endif
 
 # Archive from which to import Health Center content.


### PR DESCRIPTION
Backport pull requests [493](https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/493) & [495](https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/495) from ibmruntimes/openj9-openjdk-jdk.

Fixes: https://github.com/eclipse-openj9/openj9/issues/16436.