### PR TITLE
[Jtreg/FFI] Backport layout() for struct from JDK19 to JDK17

### DIFF
--- a/test/jdk/java/foreign/CallGeneratorHelper.java
+++ b/test/jdk/java/foreign/CallGeneratorHelper.java
@@ -145,6 +145,7 @@ public class CallGeneratorHelper extends NativeTestHelper {
             if (this == STRUCT) {
                 long offset = 0L;
                 List<MemoryLayout> layouts = new ArrayList<>();
+                long align = 0;
                 for (StructFieldType field : fields) {
                     MemoryLayout l = field.layout();
                     /* Follow the calculation of padding in JDK19 which is based on
@@ -156,7 +157,12 @@ public class CallGeneratorHelper extends NativeTestHelper {
                         offset += padding;
                     }
                     layouts.add(l.withName("field" + offset));
+                    align = Math.max(align, l.bitAlignment());
                     offset += l.bitSize();
+                }
+                long padding = offset % align;
+                if (padding != 0) {
+                    layouts.add(MemoryLayout.paddingLayout(padding));
                 }
                 return MemoryLayout.structLayout(layouts.toArray(new MemoryLayout[0]));
             } else {


### PR DESCRIPTION
The change is to backport the test code of layout() from JDK19 to JDK17
to resolve the padding & alignment issue with struct in tests given layout()
in JDK19 proves to work for all downcall && upcall specific test suites on
all supported platforms.

Fixes: https://github.com/eclipse-openj9/openj9/issues/16408

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>