### PR TITLE
Update export/import of plain keys in FIPS

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -385,8 +385,8 @@ abstract class P11Key implements Key, Length {
             new CK_ATTRIBUTE(CKA_SENSITIVE),
             new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
-        if (attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
-            if ((SunPKCS11.mysunpkcs11 != null) && "RSA".equals(algorithm)) {
+        if ((SunPKCS11.mysunpkcs11 != null) && "RSA".equals(algorithm)) {
+            if (attributes[0].getBoolean() || attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
                 try {
                     byte[] key = SunPKCS11.mysunpkcs11.exportKey(session.id(), attributes, keyID);
                     RSAPrivateKey rsaPrivKey = RSAPrivateCrtKeyImpl.newKey(KeyType.RSA, "PKCS#8", key);
@@ -399,6 +399,8 @@ abstract class P11Key implements Key, Length {
                     // Attempt failed, create a P11PrivateKey object.
                 }
             }
+        }
+        if (attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
             return new P11PrivateKey
                 (session, keyID, algorithm, keyLength, attributes);
         } else {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -47,7 +47,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -55,8 +55,6 @@ package sun.security.pkcs11.wrapper;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Consumer;
 
@@ -174,15 +172,10 @@ public class PKCS11 {
         // Overriding the JNI method C_CreateObject so that first check if FIPS mode is on and the object is a
         // secret key, in which case invoke the importKey method in SunPKCS11 provider to import the secret key
         // into the PKCS11 device.
+        @Override
         public synchronized long C_CreateObject(long hSession, CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
             if ((mysunpkcs11 != null) && isKey(pTemplate)) {
-                try {
-                    Method method = mysunpkcs11.getClass().getDeclaredMethod("importKey", long.class, CK_ATTRIBUTE[].class);
-                    method.setAccessible(true);
-                    return (Long)method.invoke(mysunpkcs11, hSession, pTemplate);
-                } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-                    throw new PKCS11Exception(CKR_GENERAL_ERROR, null);
-                }
+                return mysunpkcs11.importKey(hSession, pTemplate);
             }
             return super.C_CreateObject(hSession, pTemplate);
         }
@@ -1746,13 +1739,7 @@ static class SynchronizedPKCS11 extends PKCS11 {
     public synchronized long C_CreateObject(long hSession,
             CK_ATTRIBUTE[] pTemplate) throws PKCS11Exception {
         if ((mysunpkcs11 != null) && isKey(pTemplate)) {
-            try {
-                Method method = mysunpkcs11.getClass().getMethod("importKey", long.class, CK_ATTRIBUTE[].class);
-                method.setAccessible(true);
-                return (Long)method.invoke(mysunpkcs11, hSession, pTemplate);
-            } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-                throw new PKCS11Exception(CKR_GENERAL_ERROR, null);
-            }
+            return mysunpkcs11.importKey(hSession, pTemplate);
         }
         return super.C_CreateObject(hSession, pTemplate);
     }


### PR DESCRIPTION
Signed-off-by: Tao Liu tao.liu@ibm.com

According to the suggestion in JDK PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/469, add CKA_TOKEN in the condition for export/import plain keys in FIPS mode. And also, back-ports some changes included in JDKnext PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/469 to JDK17 for all version consistent.
