### PR TITLE
Add JPP tags at GensrcCharsetMapping.gmk

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -24,9 +24,7 @@ all :
 
 include $(SPEC)
 include $(TOPDIR)/make/common/MakeBase.gmk
-
-J9TOOLS_DIR := $(SUPPORT_OUTPUTDIR)/j9tools
-JPP_JAR     := $(J9TOOLS_DIR)/jpp.jar
+include $(TOPDIR)/closed/JPP.gmk
 
 RecursiveWildcard = $(foreach dir,$(wildcard $1/*),$(call RecursiveWildcard,$(dir),$2) $(filter $(subst *,%,$2),$(dir)))
 JppSourceDirs := $(OPENJ9_TOPDIR)/jcl/src
@@ -35,16 +33,6 @@ JppSourceDirs += $(TOPDIR)/closed/src
 ifeq (true,$(OPENJ9_ENABLE_DDR))
   JppSourceDirs += $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src
 endif # OPENJ9_ENABLE_DDR
-
-JPP_TAGS := PLATFORM-$(OPENJ9_PLATFORM_CODE)
-
-ifeq (true,$(OPENJ9_ENABLE_CRIU_SUPPORT))
-  JPP_TAGS += CRIU_SUPPORT
-endif # OPENJ9_ENABLE_CRIU_SUPPORT
-
-ifeq (true,$(OPENJ9_ENABLE_INLINE_TYPES))
-  JPP_TAGS += INLINE-TYPES
-endif # OPENJ9_ENABLE_INLINE_TYPES
 
 # OpenJ9 CRIU only supports Linux, so we only need to consider the share and unix sub-directories.
 $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
@@ -60,25 +48,6 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
 	))
 
-# invoke JPP to preprocess java source files
-# $1 - configuration
-# $2 - source directory
-# $3 - destination subdirectory (optional)
-# more arguments can be appended after the expanded RunJPP such as $(IncludeIfUnsure)
-define RunJPP
-	@$(BOOT_JDK)/bin/java \
-		-cp "$(call FixPath,$(JPP_JAR))" \
-		-Dfile.encoding=US-ASCII \
-		com.ibm.jpp.commandline.CommandlineBuilder \
-			-verdict \
-			-config $1 \
-			-baseDir "$(call FixPath,$(dir $2))" \
-			-srcRoot $(notdir $2)/ \
-			-xml "$(call FixPath,$(OPENJ9_TOPDIR)/jcl/jpp_configuration.xml)" \
-			-dest "$(call FixPath,$(J9JCL_SOURCES_DIR)$(strip $3))" \
-			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
-endef # RunJPP
-
 IncludeIfUnsure := -includeIfUnsure -noWarnIncludeIf
 
 $(J9JCL_SOURCES_DONEFILE) : \
@@ -92,16 +61,12 @@ $(J9JCL_SOURCES_DONEFILE) : \
 		JAVA_HOME=$(BOOT_JDK) \
 		preprocessor
 	@$(ECHO) Generating J9JCL sources
-	$(call RunJPP, JAVA$(VERSION_FEATURE), $(SUPPORT_OUTPUTDIR)/overlay) \
-		$(IncludeIfUnsure)
-	$(call RunJPP, JAVA$(VERSION_FEATURE), $(TOPDIR)/closed) \
-		$(IncludeIfUnsure)
-	$(call RunJPP, JAVA$(VERSION_FEATURE), $(OPENJ9_TOPDIR)/jcl)
+	$(call RunJPP, JAVA$(VERSION_FEATURE), $(SUPPORT_OUTPUTDIR)/overlay, /j9jcl, $(IncludeIfUnsure))
+	$(call RunJPP, JAVA$(VERSION_FEATURE), $(TOPDIR)/closed, /j9jcl, $(IncludeIfUnsure))
+	$(call RunJPP, JAVA$(VERSION_FEATURE), $(OPENJ9_TOPDIR)/jcl, /j9jcl)
   ifeq (true,$(OPENJ9_ENABLE_DDR))
 	@$(ECHO) Generating DDR_VM sources
-	$(call RunJPP, GENERIC, $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src, /openj9.dtfj/share/classes) \
-		$(IncludeIfUnsure) \
-		-macro:define JAVA_SPEC_VERSION=$(VERSION_FEATURE)
+	$(call RunJPP, GENERIC, $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src, /j9jcl/openj9.dtfj/share/classes, $(IncludeIfUnsure) -macro:define JAVA_SPEC_VERSION=$(VERSION_FEATURE))
   endif # OPENJ9_ENABLE_DDR
 	@$(MKDIR) -p $(@D)
 	@$(TOUCH) $@

--- a/closed/JPP.gmk
+++ b/closed/JPP.gmk
@@ -1,0 +1,63 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+J9TOOLS_DIR := $(SUPPORT_OUTPUTDIR)/j9tools
+JPP_JAR     := $(J9TOOLS_DIR)/jpp.jar
+JPP_TAGS    := PLATFORM-$(OPENJ9_PLATFORM_CODE)
+
+ifeq (true,$(OPENJ9_ENABLE_CRIU_SUPPORT))
+  JPP_TAGS += CRIU_SUPPORT
+endif # OPENJ9_ENABLE_CRIU_SUPPORT
+
+ifeq (true,$(OPENJ9_ENABLE_INLINE_TYPES))
+  JPP_TAGS += INLINE-TYPES
+endif # OPENJ9_ENABLE_INLINE_TYPES
+
+# invoke JPP to preprocess java source files
+# $1 - configuration
+# $2 - source directory
+# $3 - destination subdirectory
+# $4 - more options (optional)
+define RunJPP
+	@$(ECHO) $(BOOT_JDK)/bin/java \
+		-cp "$(call FixPath,$(JPP_JAR))" \
+		-Dfile.encoding=US-ASCII \
+		com.ibm.jpp.commandline.CommandlineBuilder \
+			-verdict \
+			-config $1 \
+			-baseDir "$(call FixPath,$(dir $2))" \
+			-srcRoot $(notdir $2)/ \
+			-xml "$(call FixPath,$(OPENJ9_TOPDIR)/jcl/jpp_configuration.xml)" \
+			-dest "$(call FixPath,$(SUPPORT_OUTPUTDIR)$(strip $3))" \
+			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))" \
+			$4
+	@$(BOOT_JDK)/bin/java \
+		-cp "$(call FixPath,$(JPP_JAR))" \
+		-Dfile.encoding=US-ASCII \
+		com.ibm.jpp.commandline.CommandlineBuilder \
+			-verdict \
+			-config $1 \
+			-baseDir "$(call FixPath,$(dir $2))" \
+			-srcRoot $(notdir $2)/ \
+			-xml "$(call FixPath,$(OPENJ9_TOPDIR)/jcl/jpp_configuration.xml)" \
+			-dest "$(call FixPath,$(SUPPORT_OUTPUTDIR)$(strip $3))" \
+			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))" \
+			$4
+endef # RunJPP

--- a/make/modules/java.base/gensrc/GensrcCharsetMapping.gmk
+++ b/make/modules/java.base/gensrc/GensrcCharsetMapping.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
 # ===========================================================================
 
 ################################################################################
@@ -32,6 +32,9 @@
 # Generate StandardCharsets.java and individul sun.nio.cs charset class using
 # the charsetmapping tool
 #
+
+include $(TOPDIR)/closed/JPP.gmk
+
 CHARSET_DATA_DIR := $(TOPDIR)/make/data/charsetmapping
 CHARSET_EXTSRC_DIR := $(TOPDIR)/src/jdk.charsets/share/classes/sun/nio/cs/ext
 CHARSET_GENSRC_JAVA_DIR_BASE := $(SUPPORT_OUTPUTDIR)/gensrc/java.base/sun/nio/cs
@@ -43,26 +46,6 @@ CHARSET_TEMPLATES := \
 CHARSET_STANDARD_JAVA_TEMPLATES := \
     $(TOPDIR)/src/java.base/share/classes/sun/nio/cs/StandardCharsets.java.template
 CHARSET_STANDARD_OS := stdcs-$(OPENJDK_TARGET_OS)
-
-J9TOOLS_DIR := $(SUPPORT_OUTPUTDIR)/j9tools
-JPP_JAR     := $(J9TOOLS_DIR)/jpp.jar
-JPP_TAGS    := PLATFORM-$(OPENJ9_PLATFORM_CODE)
-
-define RunJPP
-	@$(BOOT_JDK)/bin/java \
-		-cp "$(call FixPath,$(JPP_JAR))" \
-		-Dfile.encoding=US-ASCII \
-		com.ibm.jpp.commandline.CommandlineBuilder \
-			-verdict \
-			-config $1 \
-			-baseDir "$(call FixPath,$(dir $2))" \
-			-srcRoot $(notdir $2)/ \
-			-xml "$(call FixPath,$(OPENJ9_TOPDIR)/jcl/jpp_configuration.xml)" \
-			-dest "$(call FixPath,$(SUPPORT_OUTPUTDIR)$(strip $3))" \
-			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))" \
-			-includeIfUnsure \
-			-noWarnIncludeIf
-endef # RunJPP
 
 $(CHARSET_DONE_BASE)-stdcs: $(CHARSET_DATA_DIR)/charsets \
     $(wildcard $(CHARSET_DATA_DIR)/$(CHARSET_STANDARD_OS)) \
@@ -77,7 +60,7 @@ $(CHARSET_DONE_BASE)-stdcs: $(CHARSET_DATA_DIR)/charsets \
             $(LOG_DEBUG)
 	$(MKDIR) -p $(SUPPORT_OUTPUTDIR)/overlay-gensrc/src/java.base/sun/nio/cs
 	$(CP) $(CHARSET_GENSRC_JAVA_DIR_BASE)/StandardCharsets.java $(SUPPORT_OUTPUTDIR)/overlay-gensrc/src/java.base/sun/nio/cs/
-	$(call RunJPP, JAVA$(VERSION_FEATURE), $(SUPPORT_OUTPUTDIR)/overlay-gensrc, /overlay-result)
+	$(call RunJPP, JAVA$(VERSION_FEATURE), $(SUPPORT_OUTPUTDIR)/overlay-gensrc, /overlay-result, -includeIfUnsure -noWarnIncludeIf)
 	$(CP) $(SUPPORT_OUTPUTDIR)/overlay-result/java.base/sun/nio/cs/StandardCharsets.java $(CHARSET_GENSRC_JAVA_DIR_BASE)/
 	$(TOUCH) '$@'
 


### PR DESCRIPTION
Add `JPP.gmk` to share `JPP_TAGS`;
Ensure `JPP` tags within `StandardCharsets.java` to be processed.

Cherry-pick https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/537

Signed-off-by: Jason Feng <fengj@ca.ibm.com>