### PR TITLE
Ensure test-image-openj9 target fails when java -version fails

### DIFF
--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -79,7 +79,7 @@ ifeq ($(call isTargetOs, linux), true)
 endif
 	@+$(OPENJ9_MAKE) openj9_test_image
 ifneq ($(COMPILE_TYPE), cross)
-	$(JDK_OUTPUTDIR)/bin/java -version 2>&1 | $(TEE) $(TEST_IMAGE_DIR)/openj9/java-version.txt
+	rc=0; $(JDK_OUTPUTDIR)/bin/java -version >$(TEST_IMAGE_DIR)/openj9/java-version.txt 2>&1 || rc="$$?"; $(CAT) $(TEST_IMAGE_DIR)/openj9/java-version.txt; exit "$$rc"
 endif
 
 ALL_TARGETS += test-image-openj9


### PR DESCRIPTION
Previously, the exit status could come from `tee`, which succeeds.

There is logic in `make/autoconf/basics.m4` that checks for support and then opportunistically adds `-o pipefail` to `SHELL` in the makefiles, which already accomplishes the same thing, but only when `pipefail` support is detected. That should be most of the time, but it's not obvious that we should expect `pipefail` support in all cases.

With this change, the target will fail whenever `java -version` fails, regardless of the `pipefail` setting.