### PR TITLE
Remove obsolete loadedProps variable from java/security/Security

### DIFF
--- a/src/java.base/share/classes/java/security/Security.java
+++ b/src/java.base/share/classes/java/security/Security.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -146,14 +146,12 @@ public final class Security {
 /*[ENDIF] CRIU_SUPPORT*/
 
         // Load FIPS properties
-        if (loadedProps) {
-            boolean fipsEnabled = FIPSConfigurator.configureFIPS(props);
-            if (sdebug != null) {
-                if (fipsEnabled) {
-                    sdebug.println("FIPS mode enabled.");
-                } else {
-                    sdebug.println("FIPS mode disabled.");
-                }
+        boolean fipsEnabled = FIPSConfigurator.configureFIPS(props);
+        if (sdebug != null) {
+            if (fipsEnabled) {
+                sdebug.println("FIPS mode enabled.");
+            } else {
+                sdebug.println("FIPS mode disabled.");
             }
         }
     }


### PR DESCRIPTION
https://github.com/ibmruntimes/openj9-openjdk-jdk17/commit/19cfd727bf758 removed the variable, the FIPS code needs to reflect that.

Fixes https://github.com/eclipse-openj9/openj9/issues/16740

This is merged to the staging branch, which will trigger a new acceptance build.