### PR TITLE
(0.38) Revert "Add additional debug message to show contents of authentication reply message"

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/KDCRep.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/KDCRep.java
@@ -136,23 +136,6 @@ public class KDCRep {
                         "encoding tag is " +
                         encoding.getTag() +
                         " req type is " + req_type);
-
-                System.out.println(">>> KDCRep: Message in bytes is =>");
-                byte[] dataBytes = encoding.getDataBytes();
-                StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < dataBytes.length; i++) {
-                    if ((i % 16) == 0) {
-                        sb.append(String.format("%06X", i));
-                    }
-                    sb.append(String.format(" %02X", dataBytes[i] & 0xFF));
-                    if ((i % 16) == 15) {
-                        System.out.println(sb.toString());
-                        sb.setLength(0);
-                    }
-                }
-                if (sb.length() > 0) {
-                    System.out.println(sb.toString());
-                }
             }
             throw new Asn1Exception(Krb5.ASN1_BAD_ID);
         }


### PR DESCRIPTION
This reverts commit 8baade2afbd8df94badf3d31058fae3c7a64ffb2, https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/197

Due to https://github.com/eclipse-openj9/openj9/issues/17279