### PR TITLE
Get byte array from DerValue without using InputStream

### DIFF
--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/KDCRep.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/KDCRep.java
@@ -138,7 +138,7 @@ public class KDCRep {
                         " req type is " + req_type);
 
                 System.out.println(">>> KDCRep: Message in bytes is =>");
-                byte[] dataBytes = encoding.getDataBytes();
+                byte[] dataBytes = encoding.data().toByteArray();
                 StringBuilder sb = new StringBuilder();
                 for (int i = 0; i < dataBytes.length; i++) {
                     if ((i % 16) == 0) {


### PR DESCRIPTION
This fix eliminates the problem of emptying the input stream when reading a DerValue to print for debug purposes.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/597

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>