### PR TITLE
Add support for a suspendOnRestore option in JDWP

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -50,6 +50,12 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \
 		src/java.base/unix/classes/java/lang/ProcessEnvironment.java \
+		make/data/jdwp/jdwp.spec \
+		src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java \
+		src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventNotifier.java \
+		src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java \
+		src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java \
+		src/jdk.jdi/share/classes/com/sun/tools/jdi/EventSetImpl.java \
 	))
 
 IncludeIfUnsure := -includeIfUnsure -noWarnIncludeIf

--- a/closed/src/jdk.jdi/share/classes/com/sun/jdi/event/VMRestoreEvent.java
+++ b/closed/src/jdk.jdi/share/classes/com/sun/jdi/event/VMRestoreEvent.java
@@ -1,0 +1,50 @@
+/*[INCLUDE-IF CRIU_SUPPORT]*/
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+package com.sun.jdi.event;
+
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.VirtualMachine;
+
+/**
+ * Notification of when the VM is restored from a checkpoint. Similar to
+ * VMStartEvent this occurs before application code has run, including any
+ * application hooks for the restore event.
+ * The event is generated even if not explicitly requested.
+ *
+ * @see VMStartEvent
+ * @see VMDeathEvent
+ * @see EventQueue
+ * @see VirtualMachine
+ */
+public interface VMRestoreEvent extends Event {
+
+    /**
+     * Returns the thread which is restoring the VM from a checkpoint.
+     *
+     * @return a {@link ThreadReference} representing the restore thread
+     * on the target VM.
+     */
+    public ThreadReference thread();
+}

--- a/make/data/jdwp/jdwp.spec
+++ b/make/data/jdwp/jdwp.spec
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+ /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 JDWP "Java(tm) Debug Wire Protocol"
 (CommandSet VirtualMachine=1
@@ -3090,6 +3095,17 @@ JDWP "Java(tm) Debug Wire Protocol"
                         (int requestID
                                 "Request that generated event")
                     )
+/*[IF CRIU_SUPPORT]*/
+                    (Alt VMRestore=JDWP.EventKind.VM_RESTORE
+                        "Notification of when the VM is restored from a checkpoint. Similar to"
+                        "VMStartEvent this occurs before application code has run, including any"
+                        "application hooks for the restore event."
+                        "The event is generated even if not explicitly requested."
+
+                        (int requestID "Request that generated event")
+                        (threadObject thread "The thread restoring the VM from a checkpoint.")
+                    )
+/*[ENDIF] CRIU_SUPPORT */
                 )
             )
         )
@@ -3219,6 +3235,9 @@ JDWP "Java(tm) Debug Wire Protocol"
     (Constant VM_INIT                =90  "obsolete - was used in jvmdi")
     (Constant VM_DEATH               =99  )
     (Constant VM_DISCONNECTED        =100 "Never sent across JDWP")
+/*[IF CRIU_SUPPORT]*/
+    (Constant VM_RESTORE             =101 "OpenJ9 VM Restored")
+/*[ENDIF] CRIU_SUPPORT */
 )
 
 (ConstantSet ThreadStatus

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventHandler.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * This source code is provided to illustrate the usage of a given feature
@@ -118,6 +123,10 @@ public class EventHandler implements Runnable {
             return threadDeathEvent(event);
         } else if (event instanceof VMStartEvent) {
             return vmStartEvent(event);
+/*[IF CRIU_SUPPORT]*/
+        } else if (event instanceof VMRestoreEvent) {
+            return vmRestoreEvent(event);
+/*[ENDIF] CRIU_SUPPORT */
         } else {
             return handleExitEvent(event);
         }
@@ -179,6 +188,10 @@ public class EventHandler implements Runnable {
             return ((ThreadDeathEvent)event).thread();
         } else if (event instanceof VMStartEvent) {
             return ((VMStartEvent)event).thread();
+/*[IF CRIU_SUPPORT]*/
+        } else if (event instanceof VMRestoreEvent) {
+            return ((VMRestoreEvent)event).thread();
+/*[ENDIF] CRIU_SUPPORT */
         } else {
             return null;
         }
@@ -209,6 +222,14 @@ public class EventHandler implements Runnable {
         notifier.vmStartEvent(se);
         return stopOnVMStart;
     }
+
+/*[IF CRIU_SUPPORT]*/
+    private boolean vmRestoreEvent(Event event)  {
+        VMRestoreEvent se = (VMRestoreEvent)event;
+        notifier.vmRestoreEvent(se);
+        return stopOnVMStart;
+    }
+/*[ENDIF] CRIU_SUPPORT */
 
     private boolean breakpointEvent(Event event)  {
         BreakpointEvent be = (BreakpointEvent)event;

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventNotifier.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/EventNotifier.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * This source code is provided to illustrate the usage of a given feature
@@ -38,6 +43,9 @@ import com.sun.jdi.event.*;
 
 interface EventNotifier {
     void vmStartEvent(VMStartEvent e);
+/*[IF CRIU_SUPPORT]*/
+    void vmRestoreEvent(VMRestoreEvent e);
+/*[ENDIF] CRIU_SUPPORT */
     void vmDeathEvent(VMDeathEvent e);
     void vmDisconnectEvent(VMDisconnectEvent e);
 

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * This source code is provided to illustrate the usage of a given feature
@@ -72,6 +77,14 @@ public class TTY implements EventNotifier {
         Thread.yield();  // fetch output
         MessageOutput.lnprint("VM Started:");
     }
+
+/*[IF CRIU_SUPPORT]*/
+    @Override
+    public void vmRestoreEvent(VMRestoreEvent re)  {
+        Thread.yield();  // fetch output
+        MessageOutput.lnprint("VM Restored:");
+    }
+/*[ENDIF] CRIU_SUPPORT */
 
     @Override
     public void vmDeathEvent(VMDeathEvent e)  {

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTYResources.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * This source code is provided to illustrate the usage of a given feature
@@ -484,6 +489,9 @@ public class TTYResources extends java.util.ListResourceBundle {
              "<arguments> are the arguments passed to the main() method of <class>\n" +
              "\n" +
              "For command help type ''help'' at {0} prompt"},
+/*[IF CRIU_SUPPORT]*/
+        {"VM Restored:", "VM restored from checkpoint: "},
+/*[ENDIF] CRIU_SUPPORT */
         // END OF MATERIAL TO LOCALIZE
         };
 

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/EventSetImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/EventSetImpl.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 package com.sun.tools.jdi;
 
@@ -64,6 +69,9 @@ import com.sun.jdi.event.ThreadStartEvent;
 import com.sun.jdi.event.VMDeathEvent;
 import com.sun.jdi.event.VMDisconnectEvent;
 import com.sun.jdi.event.VMStartEvent;
+/*[IF CRIU_SUPPORT]*/
+import com.sun.jdi.event.VMRestoreEvent;
+/*[ENDIF] CRIU_SUPPORT */
 import com.sun.jdi.event.WatchpointEvent;
 import com.sun.jdi.request.EventRequest;
 
@@ -494,6 +502,19 @@ public class EventSetImpl extends ArrayList<Event> implements EventSet {
         }
     }
 
+/*[IF CRIU_SUPPORT]*/
+    class VMRestoreEventImpl extends ThreadedEventImpl implements VMRestoreEvent {
+
+        VMRestoreEventImpl(JDWP.Event.Composite.Events.VMRestore evt) {
+            super(evt, evt.requestID, evt.thread);
+        }
+
+        String eventName() {
+            return "VMRestoreEvent";
+        }
+    }
+/*[ENDIF] CRIU_SUPPORT */
+
     class VMDeathEventImpl extends EventImpl implements VMDeathEvent {
 
         VMDeathEventImpl(JDWP.Event.Composite.Events.VMDeath evt) {
@@ -804,6 +825,12 @@ public class EventSetImpl extends ArrayList<Event> implements EventSet {
             case JDWP.EventKind.VM_DEATH:
                 return new VMDeathEventImpl(
                       (JDWP.Event.Composite.Events.VMDeath)comm);
+
+/*[IF CRIU_SUPPORT]*/
+            case JDWP.EventKind.VM_RESTORE:
+                return new VMRestoreEventImpl(
+                      (JDWP.Event.Composite.Events.VMRestore)comm);
+/*[ENDIF] CRIU_SUPPORT */
 
             default:
                 // Ignore unknown event types

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include <ctype.h>
 
@@ -38,6 +43,7 @@
 #include "bag.h"
 #include "invoker.h"
 #include "sys.h"
+#include "j9cfg.h"
 
 /* How the options get to OnLoad: */
 #define XRUN "-Xrunjdwp"
@@ -74,6 +80,9 @@ static jboolean initOnUncaught = JNI_FALSE; /* init when uncaught exc thrown */
 
 static char *launchOnInit = NULL;           /* launch this app during init */
 static jboolean suspendOnInit = JNI_TRUE;   /* suspend all app threads after init */
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+static jboolean suspendOnRestore = JNI_TRUE;   /* suspend all app threads after VM restored */
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 static jboolean dopause = JNI_FALSE;        /* pause for debugger attach */
 static jboolean docoredump = JNI_FALSE;     /* core dump on exit */
 static char *logfile = NULL;                /* Name of logfile (if logging) */
@@ -101,6 +110,9 @@ static void JNICALL cbEarlyVMInit(jvmtiEnv*, JNIEnv *, jthread);
 static void JNICALL cbEarlyVMDeath(jvmtiEnv*, JNIEnv *);
 static void JNICALL cbEarlyException(jvmtiEnv*, JNIEnv *,
             jthread, jmethodID, jlocation, jobject, jmethodID, jlocation);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+static void JNICALL cbEarlyVMRestore(jvmtiEnv*, ...);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 static void initialize(JNIEnv *env, jthread thread, EventIndex triggering_ei);
 static jboolean parseOptions(char *str);
@@ -377,6 +389,16 @@ DEF_Agent_OnLoad(JavaVM *vm, char *options, void *reserved)
                         jvmtiErrorText(error), error));
         return JNI_ERR;
     }
+    /* enable extension events and set early callbacks for them */
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+    error = JVMTI_FUNC_PTR(gdata->jvmti, SetExtensionEventCallback)
+                (gdata->jvmti, eventIndex2jvmti(EI_VM_RESTORE), &cbEarlyVMRestore);
+    if (JVMTI_ERROR_NONE != error) {
+        ERROR_MESSAGE(("JDWP unable to set JVMTI extension event callbacks: %s(%d)",
+                        jvmtiErrorText(error), error));
+        return JNI_ERR;
+    }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
     LOG_MISC(("OnLoad: DONE"));
     return JNI_OK;
@@ -442,6 +464,30 @@ cbEarlyVMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread)
     vmInitialized = JNI_TRUE;
     LOG_MISC(("END cbEarlyVMInit"));
 }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+static void JNICALL
+cbEarlyVMRestore(jvmtiEnv *jvmti_env, ...)
+{
+    JNIEnv *env = NULL;
+    jthread thread = NULL;
+    va_list ap;
+
+    va_start(ap, jvmti_env);
+    env = va_arg(ap, JNIEnv *);
+    thread = va_arg (ap, jthread);
+    va_end(ap);
+
+    LOG_CB(("cbEarlyVMRestore"));
+    if (gdata->vmDead) {
+        EXIT_ERROR(AGENT_ERROR_INTERNAL, "VM dead at restore time");
+    }
+    if (suspendOnRestore) {
+        initialize(env, thread, EI_VM_RESTORE);
+    }
+    LOG_MISC(("END cbEarlyVMRestore"));
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 static void
 disposeEnvironment(jvmtiEnv *jvmti_env)
@@ -700,6 +746,14 @@ initialize(JNIEnv *env, jthread thread, EventIndex triggering_ei)
     if (error != JVMTI_ERROR_NONE) {
         EXIT_ERROR(error, "unable to clear JVMTI callbacks");
     }
+    /* Remove initial extension event callbacks and disable the events */
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+    error = JVMTI_FUNC_PTR(gdata->jvmti, SetExtensionEventCallback)
+                (gdata->jvmti, eventIndex2jvmti(EI_VM_RESTORE), NULL);
+    if (JVMTI_ERROR_NONE != error) {
+        EXIT_ERROR(error, "unable to clear extension event callbacks");
+    }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
     commonRef_initialize();
     util_initialize(env);
@@ -745,6 +799,17 @@ initialize(JNIEnv *env, jthread thread, EventIndex triggering_ei)
     if (triggering_ei == EI_VM_INIT) {
         LOG_MISC(("triggering_ei == EI_VM_INIT"));
         eventHelper_reportVMInit(env, currentSessionID, thread, suspendPolicy);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+    } else if (EI_VM_RESTORE == triggering_ei) {
+        /* Wait for a connection since if threads are suspended, we need an attached debugger
+         * to resume the VM.
+         */
+        transport_waitForConnectionOnRestore();
+
+        LOG_MISC(("triggering_ei == EI_VM_RESTORE"));
+        suspendPolicy = suspendOnRestore ? JDWP_SUSPEND_POLICY(ALL) : JDWP_SUSPEND_POLICY(NONE);
+        eventHelper_reportVMRestore(env, currentSessionID, thread, suspendPolicy);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
     } else {
         /*
          * TO DO: Kludgy way of getting the triggering event to the
@@ -826,6 +891,14 @@ debugInit_suspendOnInit(void)
 {
     return suspendOnInit;
 }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+jboolean
+debugInit_suspendOnRestore(void)
+{
+    return suspendOnRestore;
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 /*
  * code below is shamelessly swiped from hprof.
@@ -1208,6 +1281,12 @@ parseOptions(char *options)
             if ( !get_boolean(&str, &suspendOnInit) ) {
                 goto syntax_error;
             }
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+        } else if (0 == strcmp(buf, "suspendOnRestore")) {
+            if (!get_boolean(&str, &suspendOnRestore)) {
+                goto syntax_error;
+            }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
         } else if ( strcmp(buf, "server")==0 ) {
             if ( !get_boolean(&str, &isServer) ) {
                 goto syntax_error;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.h
@@ -22,9 +22,16 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #ifndef JDWP_DEBUGINIT_H
 #define JDWP_DEBUGINIT_H
+
+#include "j9cfg.h"
 
 void debugInit_waitInitComplete(void);
 jboolean debugInit_isInitComplete(void);
@@ -34,6 +41,9 @@ jboolean debugInit_isInitComplete(void);
  */
 char *debugInit_launchOnInit(void);
 jboolean debugInit_suspendOnInit(void);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+jboolean debugInit_suspendOnRestore(void);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 void debugInit_reset(JNIEnv *env);
 void debugInit_exit(jvmtiError, const char *);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
@@ -23,6 +23,11 @@
  * questions.
  */
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+/*
  * eventFilter
  *
  * This module handles event filteration and the enabling/disabling
@@ -40,6 +45,7 @@
 #include "threadControl.h"
 #include "SDE.h"
 #include "jvmti.h"
+#include "j9cfg.h"
 
 typedef struct ClassFilter {
     jclass clazz;
@@ -1240,6 +1246,9 @@ enableEvents(HandlerNode *node)
         case EI_VM_DEATH:
         case EI_CLASS_PREPARE:
         case EI_GC_FINISH:
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+        case EI_VM_RESTORE:
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
             return error;
 
         case EI_FIELD_ACCESS:
@@ -1299,6 +1308,9 @@ disableEvents(HandlerNode *node)
         case EI_VM_DEATH:
         case EI_CLASS_PREPARE:
         case EI_GC_FINISH:
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+        case EI_VM_RESTORE:
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
             return error;
 
         case EI_FIELD_ACCESS:

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -23,6 +23,11 @@
  * questions.
  */
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+/*
  * eventHandler
  *
  * This module handles events as they come in directly from JVMTI
@@ -68,6 +73,8 @@
 #include "commonRef.h"
 #include "debugLoop.h"
 #include "signature.h"
+#include "transport.h"
+#include "j9cfg.h"
 
 static HandlerID requestIdCounter;
 static jbyte currentSessionID;
@@ -1187,6 +1194,46 @@ cbVMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread)
     LOG_MISC(("END cbVMInit"));
 }
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+/* Event callback for JVMTI_EVENT_VM_RESTORE */
+static void JNICALL
+cbVMRestore(jvmtiEnv *jvmti_env, ...)
+{
+    EventInfo info;
+    JNIEnv *env = NULL;
+    jthread thread = NULL;
+    va_list ap;
+    jbyte suspendPolicy = 0;
+
+    va_start(ap, jvmti_env);
+    env = va_arg(ap, JNIEnv *);
+    thread = va_arg (ap, jthread);
+    va_end(ap);
+
+    LOG_CB(("cbVMRestore"));
+
+    BEGIN_CALLBACK() {
+        (void)memset(&info, 0, sizeof(info));
+        info.ei         = EI_VM_RESTORE;
+        info.thread     = thread;
+        event_callback(env, &info);
+    } END_CALLBACK();
+
+    /* Wait for a connection since if threads are suspended, we need an attached debugger
+     * to resume the VM.
+     */
+    transport_waitForConnectionOnRestore();
+
+    /* the VM restore extension event needs to call the helper instead of letting the normal
+     * event handler code similar to the VM init event
+     */
+    suspendPolicy = debugInit_suspendOnRestore() ? JDWP_SUSPEND_POLICY(ALL) : JDWP_SUSPEND_POLICY(NONE);
+    eventHelper_reportVMRestore(env, currentSessionID, thread, suspendPolicy);
+
+    LOG_MISC(("END cbVMRestore"));
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 /* Event callback for JVMTI_EVENT_VM_DEATH */
 static void JNICALL
 cbVMDeath(jvmtiEnv *jvmti_env, JNIEnv *env)
@@ -1203,6 +1250,14 @@ cbVMDeath(jvmtiEnv *jvmti_env, JNIEnv *env)
     if (error != JVMTI_ERROR_NONE) {
         EXIT_ERROR(error,"Can't clear event callbacks on vm death");
     }
+    /* clear extension event callbacks */
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+    error = JVMTI_FUNC_PTR(gdata->jvmti, SetExtensionEventCallback)
+                (gdata->jvmti, eventIndex2jvmti(EI_VM_RESTORE), NULL);
+    if (JVMTI_ERROR_NONE != error) {
+        EXIT_ERROR(error, "Can't clear event extension callbacks on vm death");
+    }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
     /* Now that no new callbacks will be made, we need to wait for the ones
      *   that are still active to complete.
@@ -1497,6 +1552,14 @@ eventHandler_initialize(jbyte sessionID)
     if (error != JVMTI_ERROR_NONE) {
         EXIT_ERROR(error,"Can't set event callbacks");
     }
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+    /* Enable event and set callback for VMRestore extension event */
+    error = JVMTI_FUNC_PTR(gdata->jvmti, SetExtensionEventCallback)
+                (gdata->jvmti, eventIndex2jvmti(EI_VM_RESTORE), &cbVMRestore);
+    if (JVMTI_ERROR_NONE != error) {
+        EXIT_ERROR(error, "Can't set event extension callbacks");
+    }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
     /* Notify other modules that the event callbacks are in place */
     threadControl_onHook();

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.h
@@ -22,12 +22,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #ifndef JDWP_EVENTHELPER_H
 #define JDWP_EVENTHELPER_H
 
 #include "bag.h"
 #include "invoker.h"
+#include "j9cfg.h"
 
 void eventHelper_initialize(jbyte sessionID);
 void eventHelper_reset(jbyte sessionID);
@@ -46,6 +52,9 @@ void eventHelper_recordFrameEvent(jint id, jbyte suspendPolicy, EventIndex ei,
 jbyte eventHelper_reportEvents(jbyte sessionID, struct bag *eventBag);
 void eventHelper_reportInvokeDone(jbyte sessionID, jthread thread);
 void eventHelper_reportVMInit(JNIEnv *env, jbyte sessionID, jthread thread, jbyte suspendPolicy);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+void eventHelper_reportVMRestore(JNIEnv *env, jbyte sessionID, jthread thread, jbyte suspendPolicy);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 void eventHelper_suspendThread(jbyte sessionID, jthread thread);
 
 void eventHelper_holdEvents(void);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include "util.h"
 #include "eventHandler.h"
@@ -31,6 +36,7 @@
 #include "stepControl.h"
 #include "invoker.h"
 #include "bag.h"
+#include "j9cfg.h"
 
 #define HANDLING_EVENT(node) ((node)->current_ei != 0)
 
@@ -1697,6 +1703,31 @@ threadControl_getInvokeRequest(jthread thread)
     return request;
 }
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+static jvmtiExtensionFunction
+find_ext_function(jvmtiEnv *jvmti, const char *fname)
+{
+    jint extCount = 0;
+    jvmtiExtensionFunctionInfo *extList = NULL;
+
+    jvmtiError err = JVMTI_FUNC_PTR(jvmti, GetExtensionFunctions)
+                            (jvmti, &extCount, &extList);
+    if (JVMTI_ERROR_NONE == err) {
+        for (int i = 0; i < extCount; i++) {
+            if (NULL != strstr(extList[i].id, fname)) {
+                return extList[i].func;
+            }
+        }
+    } else {
+        ERROR_MESSAGE(("Error in JVMTI GetExtensionFunctions: %s(%d)\n", jvmtiErrorText(err), err));
+    }
+    return NULL;
+}
+
+static jvmtiExtensionFunction AddDebugThreadToCheckpointState_func = NULL;
+static jvmtiExtensionFunction RemoveDebugThreadFromCheckpointState_func = NULL;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 jvmtiError
 threadControl_addDebugThread(jthread thread)
 {
@@ -1715,7 +1746,14 @@ threadControl_addDebugThread(jthread thread)
             error = AGENT_ERROR_OUT_OF_MEMORY;
         } else {
             debugThreadCount++;
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+            if (NULL == AddDebugThreadToCheckpointState_func) {
+                AddDebugThreadToCheckpointState_func = find_ext_function(gdata->jvmti, "AddDebugThreadToCheckpointState");
+            }
+            error = (*AddDebugThreadToCheckpointState_func)(gdata->jvmti, thread);
+#else
             error = JVMTI_ERROR_NONE;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
         }
     }
     debugMonitorExit(threadLock);
@@ -1742,7 +1780,14 @@ threadControl_removeDebugThread(jthread thread)
                 debugThreads[j-1] = debugThreads[j];
             }
             debugThreadCount--;
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+            if (NULL == RemoveDebugThreadFromCheckpointState_func) {
+                RemoveDebugThreadFromCheckpointState_func = find_ext_function(gdata->jvmti, "RemoveDebugThreadFromCheckpointState");
+            }
+            error = (*RemoveDebugThreadFromCheckpointState_func)(gdata->jvmti, thread);
+#else
             error = JVMTI_ERROR_NONE;
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
             break;
         }
     }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/transport.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/transport.c
@@ -22,12 +22,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include "util.h"
 #include "utf_util.h"
 #include "transport.h"
 #include "debugLoop.h"
 #include "sys.h"
+#include "j9cfg.h"
 
 static jdwpTransportEnv *transport = NULL;
 static unsigned transportVersion = JDWPTRANSPORT_VERSION_1_0;
@@ -344,6 +350,24 @@ transport_waitForConnection(void)
         debugMonitorExit(listenerLock);
     }
 }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+void
+transport_waitForConnectionOnRestore(void)
+{
+    /*
+     * If suspended on VM restore, we also need to wait for a connection,
+     * since the VM won't continue without a remote debugger telling it to.
+     */
+    if (debugInit_suspendOnRestore()) {
+        debugMonitorEnter(listenerLock);
+        while (NULL == transport) {
+            debugMonitorWait(listenerLock);
+        }
+        debugMonitorExit(listenerLock);
+    }
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 static void JNICALL
 acceptThread(jvmtiEnv* jvmti_env, JNIEnv* jni_env, void* arg)

--- a/src/jdk.jdwp.agent/share/native/libjdwp/transport.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/transport.h
@@ -22,11 +22,17 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #ifndef JDWP_TRANSPORT_H
 #define JDWP_TRANSPORT_H
 
 #include "jdwpTransport.h"
+#include "j9cfg.h"
 
 void transport_initialize(void);
 void transport_reset(void);
@@ -37,6 +43,9 @@ jint transport_receivePacket(jdwpPacket *);
 jint transport_sendPacket(jdwpPacket *);
 jboolean transport_is_open(void);
 void transport_waitForConnection(void);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+void transport_waitForConnectionOnRestore(void);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 void transport_close(void);
 
 #endif

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include <ctype.h>
 
@@ -34,6 +39,7 @@
 #include "inStream.h"
 #include "invoker.h"
 #include "signature.h"
+#include "j9cfg.h"
 
 
 /* Global data area */
@@ -1912,8 +1918,42 @@ map2jvmtiError(jdwpError error)
     return AGENT_ERROR_INTERNAL;
 }
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+static jvmtiExtensionEventInfo *
+find_ext_event(jvmtiEnv *jvmti, const char *ename)
+{
+    jint extCount = 0;
+    jvmtiExtensionEventInfo *extList = NULL;
+
+    jvmtiError err = JVMTI_FUNC_PTR(jvmti, GetExtensionEvents)
+                            (jvmti, &extCount, &extList);
+    if (JVMTI_ERROR_NONE == err) {
+        for (int i = 0; i < extCount; i++) {
+            if (NULL != strstr(extList[i].id, ename)) {
+                return &extList[i];
+            }
+        }
+    } else {
+        ERROR_MESSAGE(("Error in JVMTI GetExtensionEvents: %s(%d)\n", jvmtiErrorText(err), err));
+    }
+    return NULL;
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
 static jvmtiEvent index2jvmti[EI_max-EI_min+1];
 static jdwpEvent  index2jdwp [EI_max-EI_min+1];
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+static void
+extensionEventIndexInit(void) {
+    /* VM restore event */
+    jvmtiExtensionEventInfo *extEvent = find_ext_event(gdata->jvmti, "VMRestore");
+    if (NULL != extEvent) {
+        index2jvmti[EI_VM_RESTORE - EI_min] = extEvent->extension_event_index;
+    }
+    index2jdwp[EI_VM_RESTORE - EI_min] = JDWP_EVENT(VM_RESTORE);
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 void
 eventIndexInit(void)
@@ -1962,6 +2002,10 @@ eventIndexInit(void)
     index2jdwp[EI_MONITOR_WAITED      -EI_min] = JDWP_EVENT(MONITOR_WAITED);
     index2jdwp[EI_VM_INIT             -EI_min] = JDWP_EVENT(VM_INIT);
     index2jdwp[EI_VM_DEATH            -EI_min] = JDWP_EVENT(VM_DEATH);
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+    extensionEventIndexInit();
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 }
 
 jdwpEvent
@@ -2028,6 +2072,10 @@ eventIndex2EventName(EventIndex ei)
             return "EI_VM_INIT";
         case EI_VM_DEATH:
             return "EI_VM_DEATH";
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+        case EI_VM_RESTORE:
+            return "EI_VM_RESTORE":
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
         default:
             JDI_ASSERT(JNI_FALSE);
             return "Bad EI";
@@ -2096,6 +2144,14 @@ jdwp2EventIndex(jdwpEvent eventType)
 EventIndex
 jvmti2EventIndex(jvmtiEvent kind)
 {
+    /* JVMTI extension events */
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+    if (index2jvmti[EI_VM_RESTORE - EI_min] == kind) {
+        return EI_VM_RESTORE;
+    }
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+
+    /* normal JVMTI events*/
     switch ( kind ) {
         case JVMTI_EVENT_SINGLE_STEP:
             return EI_SINGLE_STEP;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 #ifndef JDWP_UTIL_H
 #define JDWP_UTIL_H
@@ -58,6 +63,7 @@
 #include "util_md.h"
 #include "error_messages.h"
 #include "debugInit.h"
+#include "j9cfg.h"
 
 /* Definition of a CommonRef tracked by the backend for the frontend */
 typedef struct RefNode {
@@ -167,7 +173,13 @@ typedef enum {
         EI_MONITOR_WAITED       = 18,
         EI_VM_INIT              = 19,
         EI_VM_DEATH             = 20,
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+        EI_VM_RESTORE           = 21,
+
+        EI_max                  = 21
+#else
         EI_max                  = 20
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } EventIndex;
 
 /* Agent errors that might be in a jvmtiError for JDWP or internal.


### PR DESCRIPTION
To help debug issues with checkpoint/restore, add an option similar to "suspend=y" which suspends on VM startup except this new option will suspend when the VM is restored from a checkpoint.
To that end, this PR adds support for a VM_Restore JVMTI event to JDWP and JDB.

Port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/591 to JDK17.