### PR TITLE
macOS: Stop using sprintf in java.desktop

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/font/AWTStrike.m
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (C) Copyright IBM Corp. 2023 All Rights Reserved.
+ * ===========================================================================
+ */
 
 #import "java_awt_geom_PathIterator.h"
 #import "sun_font_CStrike.h"
@@ -102,7 +107,7 @@ static CGAffineTransform sInverseTX = { 1, 0, 0, -1, 0, 0 };
 #define AWT_FONT_CLEANUP_FINISH                                         \
     if (_fontThrowJavaException == YES) {                               \
         char s[512];                                                    \
-        sprintf(s, "%s-%s:%d", __FILE__, __FUNCTION__, __LINE__);       \
+        snprintf(s, sizeof(s), "%s-%s:%d", __FILE__, __FUNCTION__, __LINE__);       \
         JNU_ThrowByName(env, "java/lang/RuntimeException", s);          \
     }
 

--- a/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_Ports.cpp
+++ b/src/java.desktop/macosx/native/libjsound/PLATFORM_API_MacOSX_Ports.cpp
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (C) Copyright IBM Corp. 2023 All Rights Reserved.
+ * ===========================================================================
+ */
 
 //#define USE_ERROR
 //#define USE_TRACE
@@ -635,7 +640,7 @@ void PORT_GetControls(void* id, INT32 portIndex, PortControlCreator* creator) {
                     if (channelName == NULL) {
                         return;
                     }
-                    sprintf(channelName, "Ch %d", ch);
+                    snprintf(channelName, 16, "Ch %d", ch);
                 }
 
                 void* jControls[2];


### PR DESCRIPTION
This commit backports the changes for macOS from Java 21, replacing sprintf() by snprintf().