### PR TITLE
Remove definition of unused macro DEFAULT_JMOD_DEPS

### DIFF
--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -31,7 +31,6 @@ JVM_MAIN_TARGETS := j9vm-build
 JVM_TOOLS_TARGETS :=
 JVM_DOCS_TARGETS :=
 JVM_TEST_IMAGE_TARGETS := test-image-openj9
-DEFAULT_JMOD_DEPS := j9vm-build
 PHASE_MAKEDIRS := $(TOPDIR)/closed/make $(PHASE_MAKEDIRS)
 
 OPENJ9_MAKE := $(MAKE) $(MAKE_ARGS) -f $(TOPDIR)/closed/OpenJ9.gmk


### PR DESCRIPTION
This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/629.