### PR TITLE
Support exporting plain SecretKey in FIPS mode

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -343,6 +343,24 @@ abstract class P11Key implements Key, Length {
             new CK_ATTRIBUTE(CKA_SENSITIVE),
             new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
+
+        if ((SunPKCS11.mysunpkcs11 != null) && !SunPKCS11.isExportWrapKey.get()
+            && ("AES".equals(algorithm) || "TripleDES".equals(algorithm))
+        ) {
+            if (attributes[0].getBoolean() || attributes[1].getBoolean() || (attributes[2].getBoolean() == false)) {
+                try {
+                    byte[] key = SunPKCS11.mysunpkcs11.exportKey(session.id(), attributes, keyID);
+                    SecretKey secretKey = new SecretKeySpec(key, algorithm);
+                    return new P11SecretKeyFIPS(session, keyID, algorithm, keyLength, attributes, secretKey);
+                } catch (PKCS11Exception e) {
+                    // Attempt failed, create a P11SecretKey object.
+                    if (debug != null) {
+                        debug.println("Attempt failed, creating a SecretKey object for " + algorithm);
+                    }
+                }
+            }
+        }
+
         return new P11SecretKey(session, keyID, algorithm, keyLength,
                 attributes);
     }
@@ -493,6 +511,29 @@ abstract class P11Key implements Key, Length {
             token.ensureValid();
             return null;
         }
+    }
+
+    private static final class P11SecretKeyFIPS extends P11Key implements SecretKey {
+        @Serial
+        private static final long serialVersionUID = -9186806495402041696L;
+        private final SecretKey key;
+
+        P11SecretKeyFIPS(Session session, long keyID, String algorithm,
+                int keyLength, CK_ATTRIBUTE[] attributes, SecretKey key) {
+            super(SECRET, session, keyID, algorithm, keyLength, attributes);
+            this.key = key;
+        }
+
+        @Override
+        public String getFormat() {
+            return "RAW";
+        }
+
+        @Override
+        byte[] getEncodedInternal() {
+            return key.getEncoded();
+        }
+
     }
 
     private static class P11SecretKey extends P11Key implements SecretKey {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -120,6 +120,8 @@ public final class SunPKCS11 extends AuthProvider {
     // FIPS mode.
     static SunPKCS11 mysunpkcs11;
 
+    static final ThreadLocal<Boolean> isExportWrapKey = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
     Token getToken() {
         return token;
     }
@@ -502,10 +504,12 @@ public final class SunPKCS11 extends AuthProvider {
 
         try {
             long genKeyId = token.p11.C_GenerateKey(wrapKeyGenSession.id(), new CK_MECHANISM(CKM_AES_KEY_GEN), wrapKeyAttributes);
+            isExportWrapKey.set(Boolean.TRUE);
             wrapKey = (P11Key)P11Key.secretKey(wrapKeyGenSession, genKeyId, "AES", 256 >> 3, null);
         } catch (PKCS11Exception e) {
             throw e;
         } finally {
+            isExportWrapKey.set(Boolean.FALSE);
             token.releaseSession(wrapKeyGenSession);
         }
 


### PR DESCRIPTION
This is a backport PR from JDKNext PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/622 to JDK17.