### PR TITLE
Integrate OpenJCEPlus into Semeru OpenJDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 # exclude all source directories
 /omr
 /openj9
+/OpenJCEPlus
 /openssl
 # exclude optional eclipse project file
 /.project

--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -49,6 +49,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java \
 		src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java \
 		src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java \
+		src/java.base/share/classes/module-info.java \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \
 		src/java.base/share/classes/sun/security/provider/DigestBase.java \

--- a/closed/JPP.gmk
+++ b/closed/JPP.gmk
@@ -34,6 +34,10 @@ ifeq (true,$(OPENJ9_ENABLE_INLINE_TYPES))
   JPP_TAGS += INLINE-TYPES
 endif # OPENJ9_ENABLE_INLINE_TYPES
 
+ifeq (true,$(BUILD_OPENJCEPLUS))
+  JPP_TAGS += OPENJCEPLUS_SUPPORT
+endif # BUILD_OPENJCEPLUS
+
 # invoke JPP to preprocess java source files
 # $1 - configuration
 # $2 - source directory

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -52,6 +52,7 @@ AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
   OPENJ9_CONFIGURE_INLINE_TYPES
   OPENJ9_THIRD_PARTY_REQUIREMENTS
   OPENJ9_CHECK_NASM_VERSION
+  OPENJCEPLUS_SETUP
 ])
 
 AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
@@ -817,4 +818,29 @@ AC_DEFUN([OPENJ9_GENERATE_TOOL_WRAPPERS],
   OPENJ9_GENERATE_TOOL_WRAPPER([ml64], [$ML64])
   OPENJ9_GENERATE_TOOL_WRAPPER([nasm], [$NASM])
   OPENJ9_GENERATE_TOOL_WRAPPER([rc], [$RC])
+])
+
+AC_DEFUN([OPENJCEPLUS_SETUP],
+[
+  AC_ARG_ENABLE([openjceplus], [AS_HELP_STRING([--enable-openjceplus],
+      [enable OpenJCEPlus integration @<:@disabled@:>@])])
+  AC_MSG_CHECKING([for OpenJCEPlus])
+  if test "x$enable_openjceplus" = xyes ; then
+    if test -d "$TOPDIR/OpenJCEPlus" ; then
+      AC_MSG_RESULT([yes (explicitly set)])
+      BUILD_OPENJCEPLUS=true
+    else
+      AC_MSG_RESULT([no])
+      AC_MSG_ERROR([OpenJCEPlus not found at $TOPDIR/OpenJCEPlus])
+    fi
+  elif test "x$enable_openjceplus" = xno ; then
+    AC_MSG_RESULT([no])
+    BUILD_OPENJCEPLUS=false
+  elif test "x$enable_openjceplus" = x ; then
+    AC_MSG_RESULT([no (default)])
+    BUILD_OPENJCEPLUS=false
+  else
+    AC_MSG_ERROR([--enable-openjceplus accepts no argument])
+  fi
+  AC_SUBST(BUILD_OPENJCEPLUS)
 ])

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -52,6 +52,7 @@ WARNING_MODULES := \
 	openj9.dtfj \
 	openj9.dtfjview \
 	openj9.traceformat \
+	openjceplus \
 	#
 
 ifneq (,$(filter $(WARNING_MODULES),$(MODULE)))
@@ -182,3 +183,7 @@ J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl.done
 
 # Disable all hotspot features.
 JVM_FEATURES_server :=
+
+# Required by OpenJCEPlus.
+BUILD_OPENJCEPLUS  := @BUILD_OPENJCEPLUS@
+OPENJCEPLUS_TOPDIR := $(TOPDIR)/OpenJCEPlus

--- a/closed/custom/Main.gmk
+++ b/closed/custom/Main.gmk
@@ -119,3 +119,23 @@ ifneq (,$(HEALTHCENTER_JAR))
   # The content must be extracted before module-info can be compiled.
   ibm.healthcenter-java : ibm.healthcenter-copy
 endif # HEALTHCENTER_JAR
+
+ifeq (true,$(BUILD_OPENJCEPLUS))
+
+ifeq ($(call And, $(call isTargetOs, windows) $(call isTargetCpu, x86_64)), true)
+  OPENJCEPLUS_JGSKIT_MAKE := jgskit.win64.mak
+else
+  OPENJCEPLUS_JGSKIT_MAKE := jgskit.mak
+endif
+
+openjceplus-copy : openjceplus-libs
+
+.PHONY : openjceplus-clean
+
+openjceplus-clean :
+	@$(ECHO) Cleaning OpenJCEPlus native code
+	$(MAKE) -C $(OPENJCEPLUS_TOPDIR)/src/main/native -f $(OPENJCEPLUS_JGSKIT_MAKE) cleanAll
+
+clean-openjceplus : openjceplus-clean
+
+endif # BUILD_OPENJCEPLUS

--- a/closed/custom/common/Modules.gmk
+++ b/closed/custom/common/Modules.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -55,6 +55,10 @@ MODULES_FILTER += \
 TOP_SRC_DIRS += \
 	$(J9JCL_SOURCES_DIR) \
 	#
+
+ifeq (true,$(BUILD_OPENJCEPLUS))
+  TOP_SRC_DIRS += $(OPENJCEPLUS_TOPDIR)/src/main
+endif
 
 .PHONY : generate-j9jcl-sources
 

--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -39,6 +39,13 @@ usage() {
 	echo "  -omr-branch       the OpenJ9/omr git branch: openj9"
 	echo "  -omr-sha          a commit SHA for the omr repository"
 	echo "  -omr-reference    a local repo to use as a clone reference"
+	echo "  -openjceplus-repo the OpenJCEPlus repository url"
+	echo "  -openjceplus-branch the OpenJCEPlus git branch"
+	echo "  -openjceplus-sha  a commit SHA for the OpenJCEPlus repository"
+	echo "  -openjceplus-reference a local repo to use as a clone reference"
+	echo "  -gskit-bin        the GSKit binary url"
+	echo "  -gskit-sdk-bin    the GSKIT SDK binary url"
+	echo "  -gskit-credential the credential for downloading the GSKit binaries"
 	echo "  -parallel         (boolean) if 'true' then the clone j9 repository commands run in parallel, default is false"
 	echo ""
 	exit 1
@@ -108,6 +115,34 @@ for i in "$@" ; do
 			references[omr]="${i#*=}"
 			;;
 
+		-openjceplus-repo=* )
+			git_urls[OpenJCEPlus]="${i#*=}"
+			;;
+
+		-openjceplus-branch=* )
+			branches[OpenJCEPlus]="${i#*=}"
+			;;
+
+		-openjceplus-sha=* )
+			shas[OpenJCEPlus]="${i#*=}"
+			;;
+
+		-openjceplus-reference=* )
+			references[OpenJCEPlus]="${i#*=}"
+			;;
+
+		-gskit-bin=* )
+			gskit_bin="${i#*=}"
+			;;
+
+		-gskit-sdk-bin=* )
+			gskit_sdk_bin="${i#*=}"
+			;;
+
+		-gskit-credential=* )
+			gskit_credential="${i#*=}"
+			;;
+
 		-parallel=* )
 			pflag="${i#*=}"
 			;;
@@ -171,6 +206,37 @@ done
 if [ ${pflag} = true ] ; then
 	# wait for all subprocesses to complete
 	wait
+fi
+
+# Download OCK binaries and create Java module folder.
+openjceplus_source=OpenJCEPlus
+if [ -n "${git_urls[$openjceplus_source]}" ] ; then
+
+	echo
+	echo "$openjceplus_source exists, download OCK binaries"
+	echo
+
+	cd $openjceplus_source
+	mkdir -p ock/jgsk_sdk/lib64
+
+	if [ -n "$gskit_credential" ] ; then
+		curl -u "$gskit_credential" $gskit_bin > ock/jgsk_crypto.tar
+		curl -u "$gskit_credential" $gskit_sdk_bin > ock/jgsk_crypto_sdk.tar
+	else
+		echo
+		echo "GSKit binaries are needed for compiling $openjceplus_source"
+		echo "Please set -gskit-bin, -gskit-sdk-bin, and -gskit-credential"
+		exit 1
+	fi
+
+	tar -xf ock/jgsk_crypto_sdk.tar -C ock
+	tar -xf ock/jgsk_crypto.tar -C ock/jgsk_sdk/lib64
+
+	# Create OpenJCEPlus Java module folder.
+	mkdir -p src/main/openjceplus/share/classes
+	cp -r src/main/java/* src/main/openjceplus/share/classes/
+
+	cd ..
 fi
 
 END_TIME=$(date +%s)

--- a/closed/make/modules/openjceplus/Copy.gmk
+++ b/closed/make/modules/openjceplus/Copy.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -18,11 +18,32 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-JRE_MODULES += \
-	$(if $(call equals, $(OPENJ9_ENABLE_CRIU_SUPPORT), true), openj9.criu) \
-	openj9.cuda \
-	openj9.dataaccess \
-	openj9.dtfj \
-	openj9.gpu \
-	$(if $(call equals, $(BUILD_OPENJCEPLUS), true), openjceplus) \
-	#
+include $(TOPDIR)/closed/CopySupport.gmk
+
+ifeq (true,$(BUILD_OPENJCEPLUS))
+  # Copy OpenJCEPlus native libraries.
+  $(eval $(call SetupCopyFiles, OPENJCEPLUS_JGSKIT_LIBS_COPY, \
+      SRC := $(OPENJCEPLUS_TOPDIR)/target, \
+      FILES := $(filter %.dll %.so %.x, $(call FindFiles, $(OPENJCEPLUS_TOPDIR)/target)), \
+      FLATTEN := true, \
+      DEST := $(LIB_DST_DIR), \
+  ))
+
+  TARGETS += $(OPENJCEPLUS_JGSKIT_LIBS_COPY)
+
+  # Bundle GSKIT library.
+  OPENJCEPLUS_OCK_DIR := $(OPENJCEPLUS_TOPDIR)/ock/jgsk_sdk/lib64
+  ifeq ($(call isTargetOs, windows), true)
+    OPENJCEPLUS_OCK_SUB_DIR := modules_cmds
+  else
+    OPENJCEPLUS_OCK_SUB_DIR := modules_libs
+  endif
+
+  $(eval $(call SetupCopyFiles, OPENJCEPLUS_OCK_COPY, \
+      SRC := $(OPENJCEPLUS_OCK_DIR), \
+      DEST := $(SUPPORT_OUTPUTDIR)/$(OPENJCEPLUS_OCK_SUB_DIR)/$(MODULE), \
+      FILES := $(call FindFiles, $(OPENJCEPLUS_OCK_DIR)), \
+  ))
+
+  TARGETS += $(OPENJCEPLUS_OCK_COPY)
+endif # BUILD_OPENJCEPLUS

--- a/closed/make/modules/openjceplus/Lib.gmk
+++ b/closed/make/modules/openjceplus/Lib.gmk
@@ -1,0 +1,69 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+include LibCommon.gmk
+
+ifeq (true,$(BUILD_OPENJCEPLUS))
+
+# Identify the desired JGSKIT target platform.
+OPENJCEPLUS_BOOT_JDK := $(BOOT_JDK)
+OPENJCEPLUS_GSKIT_HOME := $(OPENJCEPLUS_TOPDIR)/ock/jgsk_sdk
+OPENJCEPLUS_JCE_CLASSPATH := $(JDK_OUTPUTDIR)/modules/openjceplus:$(JDK_OUTPUTDIR)/modules/java.base
+OPENJCEPLUS_JGSKIT_MAKE := jgskit.mak
+OPENJCEPLUS_JGSKIT_MAKE_PATH := $(OPENJCEPLUS_TOPDIR)/src/main/native
+OPENJCEPLUS_JGSKIT_PLATFORM :=
+
+ifeq ($(call isTargetOs, aix), true)
+  OPENJCEPLUS_JGSKIT_PLATFORM := ppc-aix64
+else ifeq ($(call isTargetOs, linux), true)
+  ifeq ($(call isTargetCpu, ppc64le), true)
+    OPENJCEPLUS_JGSKIT_PLATFORM := ppcle-linux64
+  else ifeq ($(call isTargetCpu, x86_64), true)
+    OPENJCEPLUS_JGSKIT_PLATFORM := x86-linux64
+  endif
+else ifeq ($(call isTargetOs, windows), true)
+  ifeq ($(call isTargetCpu, x86_64), true)
+    OPENJCEPLUS_BOOT_JDK := $(call MixedPath,$(OPENJCEPLUS_BOOT_JDK))
+    OPENJCEPLUS_GSKIT_HOME := $(call MixedPath,$(OPENJCEPLUS_GSKIT_HOME))
+    OPENJCEPLUS_JCE_CLASSPATH := "$(call MixedPath,$(JDK_OUTPUTDIR)/modules/openjceplus)\;$(call MixedPath,$(JDK_OUTPUTDIR)/modules/java.base)"
+    OPENJCEPLUS_JGSKIT_MAKE := jgskit.win64.mak
+    OPENJCEPLUS_JGSKIT_PLATFORM := win64
+  endif
+endif
+
+ifeq (,$(OPENJCEPLUS_JGSKIT_PLATFORM))
+  $(error Unsupported platform $(OPENJDK_TARGET_OS)-$(OPENJDK_TARGET_CPU))
+endif # OPENJCEPLUS_JGSKIT_PLATFORM
+
+.PHONY : compile-libs
+
+compile-libs :
+	@$(ECHO) Compiling OpenJCEPlus native code
+	export \
+			GSKIT_HOME=$(OPENJCEPLUS_GSKIT_HOME) \
+			JAVA_HOME=$(OPENJCEPLUS_BOOT_JDK) \
+			JCE_CLASSPATH=$(OPENJCEPLUS_JCE_CLASSPATH) \
+			PLATFORM=$(OPENJCEPLUS_JGSKIT_PLATFORM) \
+		&& $(MAKE) -j1 -C $(OPENJCEPLUS_JGSKIT_MAKE_PATH) -f $(OPENJCEPLUS_JGSKIT_MAKE) all
+	@$(ECHO) OpenJCEplus compile complete
+
+TARGETS += compile-libs
+
+endif # BUILD_OPENJCEPLUS

--- a/get_source.sh
+++ b/get_source.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,13 @@ usage() {
 	echo "  -omr-branch       the OpenJ9/omr git branch: openj9"
 	echo "  -omr-sha          a commit SHA for the omr repository"
 	echo "  -omr-reference    a local repo to use as a clone reference"
+	echo "  -openjceplus-repo the OpenJCEPlus repository url"
+	echo "  -openjceplus-branch the OpenJCEPlus git branch"
+	echo "  -openjceplus-sha  a commit SHA for the OpenJCEPlus repository"
+	echo "  -openjceplus-reference a local repo to use as a clone reference"
+	echo "  -gskit-bin        the GSKit binary url"
+	echo "  -gskit-sdk-bin    the GSKIT SDK binary url"
+	echo "  -gskit-credential the credential for downloading the GSKit and GSKit SDK"
 	echo "  -parallel         (boolean) if 'true' then the clone j9 repository commands run in parallel, default is false"
 	echo "  --openssl-repo    Specify the OpenSSL repository to download from"
 	echo "  --openssl-version Specify the version of OpenSSL source to download"
@@ -57,7 +64,23 @@ for i in "$@" ; do
 			usage
 			;;
 
-		-openj9-repo=* | -openj9-branch=* | -openj9-sha=* | -openj9-reference=* | -omr-repo=* | -omr-branch=* | -omr-sha=* | -omr-reference=* | -parallel=* )
+		  -gskit-bin=* \
+		| -gskit-credential=* \
+		| -gskit-sdk-bin=* \
+		| -omr-branch=* \
+		| -omr-reference=* \
+		| -omr-repo=* \
+		| -omr-sha=* \
+		| -openj9-branch=* \
+		| -openj9-reference=* \
+		| -openj9-repo=* \
+		| -openj9-sha=* \
+		| -openjceplus-branch=* \
+		| -openjceplus-reference=* \
+		| -openjceplus-repo=* \
+		| -openjceplus-sha=* \
+		| -parallel=* \
+		)
 			j9options="${j9options} ${i}"
 			;;
 

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -182,6 +182,9 @@ module java.base {
         jdk.compiler,
         jdk.jlink;
     exports jdk.internal.logger to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         java.logging;
     exports jdk.internal.org.objectweb.asm to
         jdk.jartool,
@@ -199,6 +202,9 @@ module java.base {
     exports jdk.internal.org.xml.sax.helpers to
         jdk.jfr;
     exports jdk.internal.misc to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         java.desktop,
         java.logging,
         java.management,
@@ -279,6 +285,9 @@ module java.base {
         jdk.jconsole,
         jdk.sctp;
     exports sun.net.www to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         java.net.http,
         jdk.jartool;
     exports sun.net.www.protocol.http to
@@ -310,8 +319,14 @@ module java.base {
         jdk.crypto.ec,
         jdk.incubator.foreign;
     exports sun.security.internal.interfaces to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         jdk.crypto.cryptoki;
     exports sun.security.internal.spec to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         jdk.crypto.cryptoki;
     exports sun.security.jca to
         java.smartcardio,
@@ -319,6 +334,9 @@ module java.base {
         jdk.crypto.cryptoki,
         jdk.naming.dns;
     exports sun.security.pkcs to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         jdk.crypto.ec,
         jdk.jartool;
     exports sun.security.provider to
@@ -337,6 +355,9 @@ module java.base {
     exports sun.security.tools to
         jdk.jartool;
     exports sun.security.util to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         java.desktop,
         java.naming,
         java.rmi,
@@ -354,6 +375,9 @@ module java.base {
     exports sun.security.util.math.intpoly to
         jdk.crypto.ec;
     exports sun.security.x509 to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         jdk.crypto.ec,
         jdk.crypto.cryptoki,
         jdk.jartool;
@@ -366,6 +390,9 @@ module java.base {
         jdk.jlink,
         jdk.localedata;
     exports sun.util.logging to
+/*[IF OPENJCEPLUS_SUPPORT]*/
+        openjceplus,
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
         java.desktop,
         java.logging,
         java.prefs;


### PR DESCRIPTION
Depends on https://github.com/eclipse-openj9/openj9/pull/18544 being merged first.

Integrate the building of OpenJCEPlus with Semeru OpenJDK as a module "openjceplus". The java codes will be built with Semeru OpenJDK as a jmod, and the native codes will be built as a ".so" or ".dll" library.

The "bash get_source.sh" will download the OpenJCEPlus repo and also the ICC binaries which needed when building the OpenJCEPlus native codes.

Example:

bash get_source.sh -openjceplus-repo=[OpenJCEPlus repo] -openjceplus-branch=[OpenJCEPlus branch] -gskit-bin=[ICC binary tar file] -gskit-sdk-bin=[ICC SDK binary tar file] -gskit-credential=[Credential for downloading ICC]

bash configure --with-boot-jdk=[Boot JDK] --enable-openjceplus

Signed-off-by: Tao Liu [tao.liu@ibm.com](mailto:tao.liu@ibm.com)