### PR TITLE
Fix compile error in harfbuzz on AIX

### DIFF
--- a/src/java.desktop/share/native/libharfbuzz/hb-map.hh
+++ b/src/java.desktop/share/native/libharfbuzz/hb-map.hh
@@ -347,8 +347,7 @@ struct hb_hashmap_t
   )
   auto keys () const HB_AUTO_RETURN
   (
-    + iter_items ()
-    | hb_map (&item_t::key)
+    + keys_ref ()
     | hb_map (hb_ridentity)
   )
   auto values_ref () const HB_AUTO_RETURN
@@ -358,8 +357,7 @@ struct hb_hashmap_t
   )
   auto values () const HB_AUTO_RETURN
   (
-    + iter_items ()
-    | hb_map (&item_t::value)
+    + values_ref ()
     | hb_map (hb_ridentity)
   )
 


### PR DESCRIPTION
This is equivalent to the extra change in https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/24, but expressed the same as in harfbuzz itself.

Note, I should have requested this change in https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/243.