### PR TITLE
Add OpenJ9PropsExt properties

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -39,6 +39,10 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("docker.support", "true");
             map.put("vm.bits", vmBits());
             map.put("vm.compiler2.enabled", "false");
+            map.put("vm.gc.G1", "false");
+            map.put("vm.gc.Parallel", "false");
+            map.put("vm.gc.Serial", "false");
+            map.put("vm.gc.Shenandoah", "false");
             map.put("vm.gc.Z", "false");
             map.put("vm.graal.enabled", "false");
             map.put("vm.hasJFR", "false");


### PR DESCRIPTION
Add `OpenJ9PropsExt` properties

```
vm.gc.G1
vm.gc.Parallel
vm.gc.Serial
vm.gc.Shenandoah
```

This is to address the [JDK17 jdk_io_0_FAILED](https://hyc-runtimes-jenkins.swg-devops.com/job/Test_openjdk17_j9_extended.openjdk_aarch64_linux/123/consoleFull)
```
12:02:15  --------------------------------------------------
12:02:15  TEST: java/io/ObjectStreamClass/ObjectStreamClassCaching.java#G1
12:02:15  
12:02:15  TEST RESULT: Error. Error evaluating expression: invalid boolean value: `null' for expression `vm.gc.G1'
12:02:15  --------------------------------------------------
12:02:15  TEST: java/io/ObjectStreamClass/ObjectStreamClassCaching.java#Parallel
12:02:15  
12:02:15  TEST RESULT: Error. Error evaluating expression: invalid boolean value: `null' for expression `vm.gc.Parallel'
12:02:15  --------------------------------------------------
12:02:15  TEST: java/io/ObjectStreamClass/ObjectStreamClassCaching.java#Serial
12:02:15  
12:02:15  TEST RESULT: Error. Error evaluating expression: invalid boolean value: `null' for expression `vm.gc.Serial'
12:02:15  --------------------------------------------------
12:02:15  TEST: java/io/ObjectStreamClass/ObjectStreamClassCaching.java#Shenandoah
12:02:15  
12:02:15  TEST RESULT: Error. Error evaluating expression: invalid boolean value: `null' for expression `vm.gc.Shenandoah'
12:02:15  --------------------------------------------------
12:04:00  Test results: passed: 395; error: 4
12:04:11  Report written to /home/jenkins/workspace/Test_openjdk17_j9_extended.openjdk_aarch64_linux/aqa-tests/TKG/output_16924606647322/jdk_io_0/report/html/report.html
12:04:11  Results written to /home/jenkins/workspace/Test_openjdk17_j9_extended.openjdk_aarch64_linux/aqa-tests/TKG/output_16924606647322/jdk_io_0/work
12:04:11  Error: Some tests failed or other problems occurred.
12:04:11  -----------------------------------
12:04:11  jdk_io_0_FAILED
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>