### PR TITLE
Optimize AES/GCM cipher and IV initialization and improve array cleanup code

### DIFF
--- a/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/src/java.base/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -220,7 +220,7 @@ public class NativeCrypto {
 
     public final native int DigestReset(long context);
 
-    /* Native interfaces shared by CBC and ChaCha20 */
+    /* Native interfaces shared by CBC, ChaCha20 and GCM. */
 
     public final native long CreateContext();
 
@@ -252,7 +252,8 @@ public class NativeCrypto {
 
     /* Native GCM interfaces */
 
-    public final native int GCMEncrypt(byte[] key,
+    public final native int GCMEncrypt(long context,
+                                       byte[] key,
                                        int keylen,
                                        byte[] iv,
                                        int ivlen,
@@ -263,9 +264,12 @@ public class NativeCrypto {
                                        int outOffset,
                                        byte[] aad,
                                        int aadLen,
-                                       int tagLen);
+                                       int tagLen,
+                                       boolean newIVLen,
+                                       boolean newKeyLen);
 
-    public final native int GCMDecrypt(byte[] key,
+    public final native int GCMDecrypt(long context,
+                                       byte[] key,
                                        int keylen,
                                        byte[] iv,
                                        int ivlen,
@@ -276,7 +280,9 @@ public class NativeCrypto {
                                        int outOffset,
                                        byte[] aad,
                                        int aadLen,
-                                       int tagLen);
+                                       int tagLen,
+                                       boolean newIVLen,
+                                       boolean newKeyLen);
 
     /* Native RSA interfaces */
 

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -50,6 +50,11 @@
 #define OPENSSL_VERSION_3_0_0 OPENSSL_VERSION_CODE(3, 0, 0, 0)
 #define OPENSSL_VERSION_4_0_0 OPENSSL_VERSION_CODE(4, 0, 0, 0)
 
+/* OpenSSL operation modes. */
+#define OPENSSL_ENCRYPTION_MODE 1
+#define OPENSSL_DECRYPTION_MODE 0
+#define OPENSSL_SAME_MODE (-1)
+
 /* needed for OpenSSL 1.0.2 Thread handling routines */
 #define CRYPTO_LOCK 1
 
@@ -1312,61 +1317,33 @@ int first_time_gcm = 0;
  *
  * Class:     jdk_crypto_jniprovider_NativeCrypto
  * Method:    GCMEncrypt
- * Signature: ([BI[BI[BII[BI[BII)I
+ * Signature: (J[BI[BI[BII[BI[BIIZZ)I
  */
 JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMEncrypt
-  (JNIEnv * env, jclass obj, jbyteArray key, jint keyLen, jbyteArray iv, jint ivLen,
+  (JNIEnv * env, jclass obj, jlong context, jbyteArray key, jint keyLen, jbyteArray iv, jint ivLen,
   jbyteArray input, jint inOffset, jint inLen, jbyteArray output, jint outOffset,
-  jbyteArray aad, jint aadLen, jint tagLen)
+  jbyteArray aad, jint aadLen, jint tagLen, jboolean newIVLen, jboolean newKeyLen)
 {
-    unsigned char* inputNative = NULL;
-    int len = 0, len_cipher = 0;
-    unsigned char* keyNative = NULL;
-    unsigned char* ivNative = NULL;
-    unsigned char* outputNative = NULL;
-    unsigned char* aadNative = NULL;
+    jint ret = -1;
 
-    EVP_CIPHER_CTX* ctx = NULL;
-    const EVP_CIPHER* evp_gcm_cipher = NULL;
+    int len = 0;
+    int len_cipher = 0;
+    unsigned char *keyNative = NULL;
+    unsigned char *ivNative = NULL;
+    unsigned char *inputNative = NULL;
+    unsigned char *outputNative = NULL;
+    unsigned char *aadNative = NULL;
 
-    keyNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, key, 0));
-    if (NULL == keyNative) {
-        return -1;
+    EVP_CIPHER_CTX *ctx = (EVP_CIPHER_CTX *)(intptr_t) context;
+    const EVP_CIPHER *evp_gcm_cipher = NULL;
+
+    if (NULL == ctx) {
+        printErrors();
+        goto cleanup;
     }
 
-    ivNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, iv, 0));
-    if (NULL == ivNative) {
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        return -1;
-    }
-
-    aadNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, aad, 0));
-    if (NULL == aadNative) {
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        return -1;
-    }
-
-    outputNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, output, 0));
-    if (NULL == outputNative) {
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        return -1;
-    }
-
-    if (inLen > 0) {
-        inputNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, input, 0));
-        if (NULL == inputNative) {
-            (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-            return -1;
-        }
-    }
-
-    switch(keyLen) {
+    if (newKeyLen) {
+        switch (keyLen) {
         case 16:
             evp_gcm_cipher = (*OSSL_aes_128_gcm)();
             break;
@@ -1378,196 +1355,133 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMEncrypt
             break;
         default:
             break;
-    }
-
-    ctx = (*OSSL_CIPHER_CTX_new)();
-    if (NULL == ctx) {
-        printErrors();
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
         }
-        return -1;
-    }
 
-    if (1 != (*OSSL_CipherInit_ex)(ctx, evp_gcm_cipher, NULL, NULL, NULL, 1 )) { /* 1 - Encrypt mode 0 Decrypt Mode*/
-        printErrors();
-        (*OSSL_CIPHER_CTX_free)(ctx);
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
+        if (1 != (*OSSL_CipherInit_ex)(ctx, evp_gcm_cipher, NULL, NULL, NULL, OPENSSL_SAME_MODE)) {
+            printErrors();
+            goto cleanup;
         }
-        return -1;
     }
 
-    if (1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_SET_IVLEN, ivLen, NULL)) {
-        printErrors();
-        (*OSSL_CIPHER_CTX_free)(ctx);
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
+    if (newIVLen) {
+        if (1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_SET_IVLEN, ivLen, NULL)) {
+            printErrors();
+            goto cleanup;
         }
-        return -1;
     }
 
-    if (1 != (*OSSL_CipherInit_ex)(ctx, NULL, NULL, keyNative, ivNative, -1)) {
+    /* Initialize context with key and IV. */
+    keyNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, key, 0));
+    if (NULL == keyNative) {
+        goto cleanup;
+    }
+
+    ivNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, iv, 0));
+    if (NULL == ivNative) {
+        goto cleanup;
+    }
+
+    if (1 != (*OSSL_CipherInit_ex)(ctx, NULL, NULL, keyNative, ivNative, OPENSSL_ENCRYPTION_MODE)) {
         printErrors();
-        (*OSSL_CIPHER_CTX_free)(ctx);
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-        }
-        return -1;
+        goto cleanup;
     }
 
-    /* provide AAD */
+    /* Provide AAD. */
+    aadNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, aad, 0));
+    if (NULL == aadNative) {
+        goto cleanup;
+    }
+
     if (1 != (*OSSL_CipherUpdate)(ctx, NULL, &len, aadNative, aadLen)) {
         printErrors();
-        (*OSSL_CIPHER_CTX_free)(ctx);
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-        }
-        return -1;
+        goto cleanup;
     }
 
-    /* encrypt plaintext and obtain ciphertext */
+    outputNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, output, 0));
+    if (NULL == outputNative) {
+        goto cleanup;
+    }
+
+    /* Encrypt plaintext, if available and obtain ciphertext. */
     if (inLen > 0) {
+        inputNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, input, 0));
+        if (NULL == inputNative) {
+            goto cleanup;
+        }
+
         if (1 != (*OSSL_CipherUpdate)(ctx, outputNative + outOffset, &len, inputNative + inOffset, inLen)) {
             printErrors();
-            (*OSSL_CIPHER_CTX_free)(ctx);
-            (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-            if (inLen > 0) {
-                (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-            }
-            return -1;
+            goto cleanup;
         }
         len_cipher = len;
     }
 
-    /* finalize the encryption */
+    /* Finalize the encryption. */
     if (1 != (*OSSL_CipherFinal_ex)(ctx, outputNative + outOffset + len_cipher, &len)) {
         printErrors();
-        (*OSSL_CIPHER_CTX_free)(ctx);
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-        }
-        return -1;
+        goto cleanup;
     }
+    len_cipher += len;
 
-    /* Get the tag, place it at the end of the cipherText buffer */
-    if (1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_GET_TAG, tagLen, outputNative + outOffset + len + len_cipher)) {
+    /* Get the tag, place it at the end of the cipherText buffer. */
+    if (1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_GET_TAG, tagLen, outputNative + outOffset + len_cipher)) {
         printErrors();
-        (*OSSL_CIPHER_CTX_free)(ctx);
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-        }
-        return -1;
+        goto cleanup;
     }
 
-    (*OSSL_CIPHER_CTX_free)(ctx);
+    ret = (jint)len_cipher;
 
-    (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-    (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-    (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, 0);
-
-    if (inLen > 0) {
+cleanup:
+    if (NULL != inputNative) {
         (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
     }
+    if (NULL != outputNative) {
+        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, 0);
+    }
+    if (NULL != aadNative) {
+        (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
+    }
+    if (NULL != ivNative) {
+        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
+    }
+    if (NULL != keyNative) {
+        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
+    }
 
-    (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-
-    return (jint)len_cipher;
+    return ret;
 }
 
 /* GCM Decryption
  *
  * Class:     jdk_crypto_jniprovider_NativeCrypto
  * Method:    GCMDecrypt
- * Signature: ([BI[BI[BII[BI[BII)I
+ * Signature: (J[BI[BI[BII[BI[BIIZZ)I
  */
 JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMDecrypt
-  (JNIEnv * env, jclass obj, jbyteArray key, jint keyLen, jbyteArray iv, jint ivLen,
+  (JNIEnv * env, jclass obj, jlong context, jbyteArray key, jint keyLen, jbyteArray iv, jint ivLen,
   jbyteArray input, jint inOffset, jint inLen, jbyteArray output, jint outOffset,
-  jbyteArray aad, jint aadLen, jint tagLen)
+  jbyteArray aad, jint aadLen, jint tagLen, jboolean newIVLen, jboolean newKeyLen)
 {
-    unsigned char* inputNative = NULL;
-    unsigned char* aadNative = NULL;
-    int ret = 0, len = 0, plaintext_len = 0;
-    unsigned char* keyNative = NULL;
-    unsigned char* ivNative = NULL;
-    unsigned char* outputNative = NULL;
-    EVP_CIPHER_CTX* ctx = NULL;
-    const EVP_CIPHER* evp_gcm_cipher = NULL;
+    jint ret = -1;
 
-    keyNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, key, 0));
-    if (NULL == keyNative) {
-        return -1;
+    int len = 0;
+    int plaintext_len = 0;
+    unsigned char *keyNative = NULL;
+    unsigned char *ivNative = NULL;
+    unsigned char *aadNative = NULL;
+    unsigned char *inputNative = NULL;
+    unsigned char *outputNative = NULL;
+
+    EVP_CIPHER_CTX *ctx = (EVP_CIPHER_CTX *)(intptr_t) context;
+    const EVP_CIPHER *evp_gcm_cipher = NULL;
+
+    if (NULL == ctx) {
+        printErrors();
+        goto cleanup;
     }
 
-    ivNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, iv, 0));
-    if (NULL == ivNative) {
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        return -1;
-    }
-
-    outputNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, output, 0));
-    if (NULL == outputNative) {
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        return -1;
-    }
-
-    if (inLen > 0) {
-        inputNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, input, 0));
-        if (NULL == inputNative) {
-            (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-            return -1;
-        }
-    }
-
-    if (aadLen > 0) {
-        aadNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, aad, 0));
-        if (NULL == aadNative) {
-            (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-            if (inLen > 0) {
-                (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-            }
-            return -1;
-        }
-    }
-
-    switch(keyLen) {
+    if (newKeyLen) {
+        switch (keyLen) {
         case 16:
             evp_gcm_cipher = (*OSSL_aes_128_gcm)();
             break;
@@ -1579,131 +1493,102 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMDecrypt
             break;
         default:
             break;
+        }
+
+        if (1 != (*OSSL_CipherInit_ex)(ctx, evp_gcm_cipher, NULL, NULL, NULL, OPENSSL_DECRYPTION_MODE)) {
+            printErrors();
+            goto cleanup;
+        }
     }
 
-    ctx = (*OSSL_CIPHER_CTX_new)();
-
-    if (1 != (*OSSL_CipherInit_ex)(ctx, evp_gcm_cipher, NULL, NULL, NULL, 0 )) { /* 1 - Encrypt mode 0 Decrypt Mode*/
-        printErrors();
-        (*OSSL_CIPHER_CTX_free)(ctx);
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
+    if (newIVLen) {
+        if (1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_SET_IVLEN, ivLen, NULL)) {
+            printErrors();
+            goto cleanup;
         }
-        if (aadLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        }
-        return -1;
     }
 
-    if (1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_SET_IVLEN, ivLen, NULL)) {
-        printErrors();
-        (*OSSL_CIPHER_CTX_free)(ctx);
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-        }
-        if (aadLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        }
-        return -1;
+    /* Initialise context with key and IV. */
+    keyNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, key, 0));
+    if (NULL == keyNative) {
+        goto cleanup;
     }
 
-    /* Initialise key and IV */
+    ivNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, iv, 0));
+    if (NULL == ivNative) {
+        goto cleanup;
+    }
+
     if (0 == (*OSSL_DecryptInit_ex)(ctx, NULL, NULL, keyNative, ivNative)) {
         printErrors();
-        (*OSSL_CIPHER_CTX_free)(ctx);
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-        }
-        if (aadLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        }
-        return -1;
+        goto cleanup;
     }
 
-    /* Provide any AAD data */
+    /* Provide any AAD data. */
     if (aadLen > 0) {
+        aadNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, aad, 0));
+        if (NULL == aadNative) {
+            goto cleanup;
+        }
+
         if (0 == (*OSSL_DecryptUpdate)(ctx, NULL, &len, aadNative, aadLen)) {
             printErrors();
-            (*OSSL_CIPHER_CTX_free)(ctx);
-            (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-            if (inLen > 0) {
-                (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-            }
-            if (aadLen > 0) {
-                (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-            }
-            return -1;
+            goto cleanup;
+        }
+    }
+
+    outputNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, output, 0));
+    if (NULL == outputNative) {
+        goto cleanup;
+    }
+
+    if (inLen > 0) {
+        inputNative = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, input, 0));
+        if (NULL == inputNative) {
+            goto cleanup;
         }
     }
 
     if (inLen - tagLen > 0) {
         if (0 == (*OSSL_DecryptUpdate)(ctx, outputNative + outOffset, &len, inputNative + inOffset, inLen - tagLen)) {
             printErrors();
-            (*OSSL_CIPHER_CTX_free)(ctx);
-            (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-            (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-            if (inLen > 0) {
-                (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-            }
-            if (aadLen > 0) {
-                (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-            }
-            return -1;
+            goto cleanup;
         }
         plaintext_len = len;
     }
 
     if (0 == (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_SET_TAG, tagLen, inputNative + inOffset + inLen - tagLen)) {
         printErrors();
-        (*OSSL_CIPHER_CTX_free)(ctx);
-        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, JNI_ABORT);
-        if (inLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
-        }
-        if (aadLen > 0) {
-            (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
-        }
-        return -1;
+        goto cleanup;
     }
 
-    ret = (*OSSL_DecryptFinal)(ctx, outputNative + outOffset + len, &len);
+    if (0 < (*OSSL_DecryptFinal)(ctx, outputNative + outOffset + len, &len)) {
+        /* Decryption was successful. */
+        plaintext_len += len;
+        ret = (jint)plaintext_len;
+    } else {
+        /* There was a tag mismatch. */
+        ret = -2;
+    }
 
-    (*OSSL_CIPHER_CTX_free)(ctx);
-
-    (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
-    (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
-    (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, 0);
-
-    if (inLen > 0) {
+cleanup:
+    if (NULL != inputNative) {
         (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, JNI_ABORT);
     }
-
-    if (aadLen > 0) {
+    if (NULL != outputNative) {
+        (*env)->ReleasePrimitiveArrayCritical(env, output, outputNative, 0);
+    }
+    if (NULL != aadNative) {
         (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative, JNI_ABORT);
     }
-
-    if (ret > 0) {
-        /* Successful Decryption */
-        plaintext_len += len;
-        return (jint)plaintext_len;
-    } else {
-        /* Tag Mismatch */
-        return -2;
+    if (NULL != ivNative) {
+        (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative, JNI_ABORT);
     }
+    if (NULL != keyNative) {
+        (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative, JNI_ABORT);
+    }
+
+    return ret;
 }
 
 BIGNUM* convertJavaBItoBN(unsigned char* in, int len);
@@ -2222,13 +2107,13 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_ChaCha20Init
     unsigned char *ivNative = NULL;
     unsigned char *keyNative = NULL;
     const EVP_CIPHER *evp_cipher1 = NULL;
-    int encrypt = -1;
+    int encrypt = OPENSSL_SAME_MODE;
 
     if (NULL == ctx) {
         return -1;
     }
 
-    if ((0 == mode) || (1 == mode)) {
+    if ((OPENSSL_DECRYPTION_MODE == mode) || (OPENSSL_ENCRYPTION_MODE == mode)) {
         /* Use the existing evp_cipher? */
         if (JNI_FALSE == doReset) {
             evp_cipher1 = (*OSSL_chacha20_poly1305)();
@@ -2240,7 +2125,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_ChaCha20Init
             evp_cipher1 = (*OSSL_chacha20)();
         }
         /* encrypt or decrypt does not matter */
-        encrypt = 1;
+        encrypt = OPENSSL_ENCRYPTION_MODE;
     } else {
         return -1;
     }


### PR DESCRIPTION
The cipher initialization cost has been found to be computationally expensive, especially in the OpenSSL 3.x API.

In order to optimize the cost of using OpenSSL to perform consecutive AES/GCM encryption and decryption operations, two flags are set and passed as parameters.

The first flag indicates whether a different cipher is required for the upcoming operations (i.e., the key size has changed). If that is the case, a cipher is initialized and set to the provided context. If not, those steps are omitted, thus reducing the time required for the operation.

The second flag indicates whether the IV length has changed and is used in a similar way as the first flag.

The rest of the steps required for the operation are performed regardless of the flags.

The handling of freeing arrays that were part of that functionality is, also, updated to comply with the newer approach to cleanup code.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/655

Signed-off by: Kostas Tsiounis <kostas.tsiounis@ibm.com>