### PR TITLE
Zero out previous key in native ChaCha20 cipher init

### DIFF
--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeChaCha20Cipher.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeChaCha20Cipher.java
@@ -561,6 +561,9 @@ abstract class NativeChaCha20Cipher extends CipherSpi {
         // assigning them to the object.
         byte[] newKeyBytes = getEncodedKey(key);
         checkKeyAndNonce(newKeyBytes, newNonce);
+        if (this.keyBytes != null) {
+            Arrays.fill(this.keyBytes, (byte)0);
+        }
         this.keyBytes = newKeyBytes;
         nonce = newNonce;
 


### PR DESCRIPTION
When reinitializing a `NativeChaCha20Cipher` instance with a new key, the array containing the previous key needs to be zeroed out to prevent information leak.

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)