### PR TITLE
Ignore verbosegc files in TestVersionedStream

### DIFF
--- a/test/jdk/java/util/jar/JarFile/mrjar/TestVersionedStream.java
+++ b/test/jdk/java/util/jar/JarFile/mrjar/TestVersionedStream.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 8163798 8189611 8211728
  * @summary basic tests for multi-release jar versioned streams
@@ -108,7 +114,7 @@ public class TestVersionedStream {
     @AfterClass
     public void close() throws IOException {
         Files.walk(userdir, 1)
-                .filter(p -> !p.equals(userdir))
+                .filter(p -> !p.equals(userdir) && !p.getFileName().toString().startsWith("verbosegc"))
                 .forEach(p -> {
                     try {
                         if (Files.isDirectory(p)) {


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/18512
Related to https://github.com/adoptium/aqa-tests/pull/4873