### PR TITLE
Restore behavior on platforms where CRIU is supported but not in use

### DIFF
--- a/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
+++ b/src/java.base/unix/classes/sun/security/provider/NativePRNG.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -507,8 +507,9 @@ public final class NativePRNG extends SecureRandomSpi {
                 if (in.readNBytes(data, 0, len) < len) {
                     throw new IOException("Could not read from file(s)");
                 }
+                return;
             }
-            /*[ELSE] CRIU_SUPPORT */
+            /*[ENDIF] CRIU_SUPPORT */
             int ofs = 0;
             while (len > 0) {
                 int k = in.read(data, ofs, len);
@@ -521,7 +522,6 @@ public final class NativePRNG extends SecureRandomSpi {
             if (len > 0) {
                 throw new IOException("Could not read from file(s)");
             }
-            /*[ENDIF] CRIU_SUPPORT */
         }
 
         // get true random bytes, just read from "seed"
@@ -633,8 +633,9 @@ public final class NativePRNG extends SecureRandomSpi {
                         for (int i = 0; i < data.length; i++) {
                             data[i] ^= rawData[i];
                         }
+                        return;
                     }
-                    /*[ELSE] CRIU_SUPPORT */
+                    /*[ENDIF] CRIU_SUPPORT */
                     int data_len = data.length;
                     int ofs = 0;
                     int len;
@@ -664,7 +665,6 @@ public final class NativePRNG extends SecureRandomSpi {
                         }
                     data_len -= len;
                     }
-                    /*[ENDIF] CRIU_SUPPORT */
                 } catch (IOException e){
                     throw new ProviderException("nextBytes() failed", e);
                 }


### PR DESCRIPTION
This PR aims to fix an issue on how to read random data and
get random bytes on platforms where CRIU is supported, but
not in use by enabling it via a --enable-criu-support JVM
option.

Issue https://github.com/eclipse-openj9/openj9/issues/18602