### PR TITLE
Add provider name and class name mapping in Restricted Security mode

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -687,11 +687,19 @@ public final class RestrictedSecurity {
 
                 // Remove the provider's optional arguments if there are.
                 pos = providerName.indexOf(' ');
-                providerName = (pos < 0) ? providerName.trim() : providerName.substring(0, pos).trim();
-                // Remove the provider's class package names if there are.
-                pos = providerName.lastIndexOf('.');
-                providerName = (pos < 0) ? providerName : providerName.substring(pos + 1, providerName.length());
-                // Provider without arguments and package names.
+                if (pos >= 0) {
+                    providerName = providerName.substring(0, pos);
+                }
+                providerName = providerName.trim();
+
+                // Remove argument, e.g. -NSS-FIPS, if present.
+                pos = providerName.indexOf('-');
+                if (pos >= 0) {
+                    providerName = providerName.substring(0, pos);
+                }
+
+                // Provider name defined in provider construction method.
+                providerName = getProvidersSimpleName(providerName);
                 providersSimpleName.add(pNum - 1, providerName);
             }
 
@@ -959,11 +967,12 @@ public final class RestrictedSecurity {
 
             // Remove argument, e.g. -NSS-FIPS, if there is.
             int pos = providerName.indexOf('-');
-            providerName = (pos < 0) ? providerName : providerName.substring(0, pos);
+            if (pos >= 0) {
+                providerName = providerName.substring(0, pos);
+            }
 
-            // Remove the provider class package name if there is.
-            pos = providerName.lastIndexOf('.');
-            providerName = (pos < 0) ? providerName : providerName.substring(pos + 1, providerName.length());
+            // Provider name defined in provider construction method.
+            providerName = getProvidersSimpleName(providerName);
 
             // Check if the provider is in restricted security provider list.
             // If not, the provider won't be registered.
@@ -986,6 +995,27 @@ public final class RestrictedSecurity {
                 }
             }
             return false;
+        }
+
+        /**
+         * Get the provider name defined in provider construction method.
+         *
+         * @param providerName provider name or provider with packages
+         * @return provider name defined in provider construction method
+         */
+        private static String getProvidersSimpleName(String providerName) {
+            if (providerName.equals("com.sun.security.sasl.Provider")) {
+                // The main class for the SunSASL provider is com.sun.security.sasl.Provider.
+                return "SunSASL";
+            } else {
+                // Remove the provider's class package names if present.
+                int pos = providerName.lastIndexOf('.');
+                if (pos >= 0) {
+                    providerName = providerName.substring(pos + 1);
+                }
+                // Provider without package names.
+                return providerName;
+            }
         }
 
         /**


### PR DESCRIPTION
This is a back-port PR from PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/722

For the Java security providers, for example, the SunSASL, its class name is com.sun.security.sasl.Provider. From the provider class name, can not get the provider name which defined in its construction method. So, add the mapping between the provider name and its class name in Restricted Security mode.