### PR TITLE
Update Java Restricted Security Mode comment in java.security

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -82,10 +82,12 @@ security.provider.tbd=Apple
 #endif
 security.provider.tbd=SunPKCS11
 
-#if defined linux-x86 || defined linux-ppc || defined linux-s390
+#if defined aix-ppc || defined linux-ppc || defined linux-s390 || defined linux-x86 || defined windows
 #
 # Java Restricted Security Mode
 #
+#endif
+#if defined linux-ppc || defined linux-s390 || defined linux-x86
 RestrictedSecurity.NSS.140-2.desc.name = Red Hat Enterprise Linux 8 NSS Cryptographic Module FIPS 140-2
 RestrictedSecurity.NSS.140-2.desc.default = true
 RestrictedSecurity.NSS.140-2.desc.fips = true


### PR DESCRIPTION
This is a back-port PR from JDKNext PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/737

The Java Restricted Security Mode comment in java.security file should be presented on all platforms that have either NSS FIPS 140-2 or OpenJCEPlus FIPS 140-3 supported.