### PR TITLE
Add vm.debug (false) jtreg test property

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2024 All Rights Reserved
  * ===========================================================================
  * 
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("docker.support", "true");
             map.put("vm.bits", vmBits());
             map.put("vm.compiler2.enabled", "false");
+            map.put("vm.debug", "false");
             map.put("vm.gc.G1", "false");
             map.put("vm.gc.Parallel", "false");
             map.put("vm.gc.Serial", "false");


### PR DESCRIPTION
java/lang/ProcessBuilder/JspawnhelperProtocol.java is failing to find the property in the acceptance build.

Tested via grinder, which passed.
https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3211/