### PR TITLE
FIPS excludes java/util/jar/JarFile/SignedJarPendingBlock.java

### DIFF
--- a/test/jdk/ProblemList-FIPS140_2.txt
+++ b/test/jdk/ProblemList-FIPS140_2.txt
@@ -1223,6 +1223,7 @@ com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java https://github.com/ibmrun
 sun/security/x509/X509CertImpl/V3Certificate.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x
 
 # Temporary Exclusion
-java/util/jar/JarFile/VerifySignedJar.java https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x
 com/sun/jndi/ldap/LdapSSLHandshakeFailureTest.java https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x
+java/util/jar/JarFile/SignedJarPendingBlock.java https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x
+java/util/jar/JarFile/VerifySignedJar.java https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x
 javax/smartcardio/TerminalFactorySpiTest.java https://github.ibm.com/runtimes/backlog/issues/1089 linux-x64,linux-ppc64le,linux-s390x


### PR DESCRIPTION
FIPS excludes `java/util/jar/JarFile/SignedJarPendingBlock.java`

Addressed [internal FIPS failure](https://hyc-runtimes-jenkins.swg-devops.com/job/Test_openjdk17_j9_sanity.openjdk_ppc64le_linux_fips140_2_testList_0/17/)

Already excluded for JDK 11/21.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>