### PR TITLE
Parse jar index when using SCC

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 1997, 2020 All Rights Reserved
+ * (c) Copyright IBM Corp. 1997, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -101,6 +101,7 @@ public class URLClassPath {
     private static final boolean DISABLE_ACC_CHECKING;
     private static final boolean DISABLE_CP_URL_CHECK;
     private static final boolean DEBUG_CP_URL_CHECK;
+    private static final boolean DISABLE_JAR_INDEX;    //OpenJ9-shared_classes_misc
 
     static {
         Properties props = GetPropertyAction.privilegedGetProperties();
@@ -120,6 +121,9 @@ public class URLClassPath {
         // the check is not disabled).
         p = props.getProperty("jdk.net.URLClassPath.showIgnoredClassPathEntries");
         DEBUG_CP_URL_CHECK = p != null ? p.equals("true") || p.isEmpty() : false;
+
+        p = props.getProperty("com.ibm.oti.shared.disableJarIndex");                //OpenJ9-shared_classes_misc
+        DISABLE_JAR_INDEX = p != null ? p.equals("true") || p.isEmpty() : false;    //OpenJ9-shared_classes_misc
     }
 
     /* The original search path of URLs. */
@@ -1222,6 +1226,37 @@ public class URLClassPath {
 
             ensureOpen();
 
+            if (usingSharedClasses && !DISABLE_JAR_INDEX) {                                               //OpenJ9-shared_classes_misc
+                /* If usingSharedClasses is true, ensureOpen() does not use and set jar index.            //OpenJ9-shared_classes_misc
+                 * If usingSharedClasses is false, ensureOpen() uses and sets jar index (if it exists).   //OpenJ9-shared_classes_misc
+                 * Go through jar index here so that class path in jar index is searched.                 //OpenJ9-shared_classes_misc
+                 */                                                                                       //OpenJ9-shared_classes_misc
+                JarIndex localIndex = JarIndex.getJarIndex(jar);                                          //OpenJ9-shared_classes_misc
+                if (localIndex != null) {                                                                 //OpenJ9-shared_classes_misc
+                    String[] jarfiles = localIndex.getJarFiles();                                         //OpenJ9-shared_classes_misc
+                    URL[] urls = new URL[jarfiles.length];                                                //OpenJ9-shared_classes_misc
+                    int count = 0;                                                                        //OpenJ9-shared_classes_misc
+                    for (int i = 0; i < jarfiles.length; i++) {                                           //OpenJ9-shared_classes_misc
+                        try {                                                                             //OpenJ9-shared_classes_misc
+                            URL jarURL = new URL(csu, jarfiles[i]);                                       //OpenJ9-shared_classes_misc
+                            urls[count] = jarURL;                                                         //OpenJ9-shared_classes_misc
+                            count++;                                                                      //OpenJ9-shared_classes_misc
+                        } catch (MalformedURLException e) {                                               //OpenJ9-shared_classes_misc
+                            continue;                                                                     //OpenJ9-shared_classes_misc
+                        }                                                                                 //OpenJ9-shared_classes_misc
+                    }                                                                                     //OpenJ9-shared_classes_misc
+                    if (count > 0) {                                                                      //OpenJ9-shared_classes_misc
+                        urls = Arrays.copyOf(urls, count);                                                //OpenJ9-shared_classes_misc
+                    } else {                                                                              //OpenJ9-shared_classes_misc
+                        urls = null;                                                                      //OpenJ9-shared_classes_misc
+                    }                                                                                     //OpenJ9-shared_classes_misc
+                    /*                                                                                    //OpenJ9-shared_classes_misc
+                     * If jar index exists, class path in manifest is ignored, directly return here.      //OpenJ9-shared_classes_misc
+                     * (See the check of index != null at the beginning of this function)                 //OpenJ9-shared_classes_misc
+                     */                                                                                   //OpenJ9-shared_classes_misc
+                    return urls;                                                                          //OpenJ9-shared_classes_misc
+                }                                                                                         //OpenJ9-shared_classes_misc
+            }                                                                                             //OpenJ9-shared_classes_misc
             // Only get manifest when necessary
             if (SharedSecrets.javaUtilJarAccess().jarFileHasClassPathAttribute(jar)) {
                 Manifest man = jar.getManifest();


### PR DESCRIPTION
If a jarIndex exists, the JDK by default (i.e. SCC is off) uses the URLs in the JarIndex to search for resources, the class path in manifest is ignored.

However, when SCC is on, the jarIndex is always ignored and the class path in manifest is used, which differs from the default JDK behavior. 

Change SCC code in URLClassPath to always use URLs in jarIndex if it exists.

Add a property "com.ibm.oti.shared.disableJarIndex" that can be used to control the behavior.

JarIndex is removed in Java 21, no need to port to Java 21+.

Internal issue semeru-runtimes/issues/1