### PR TITLE
Add MemberName finalizer to mark clazz for MemberName list pruning

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import sun.invoke.util.BytecodeDescriptor;
@@ -1194,6 +1200,13 @@ final class MemberName implements Member, Cloneable {
             for (int i = 0; i < length; i++)
                 buf[i] = new MemberName();
             return buf;
+        }
+    }
+
+    @Override
+    protected void finalize() {
+        if (null != clazz) {
+            MethodHandleNatives.markClassForMemberNamePruning(clazz);
         }
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleNatives.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import jdk.internal.access.JavaLangAccess;
@@ -690,4 +696,9 @@ class MethodHandleNatives {
         UNSAFE.ensureClassInitialized(c);
         return JLA.classData(c);
     }
+
+    /**
+     * Inform the VM that a MemberName belonging to class c has been collected.
+     */
+    static native void markClassForMemberNamePruning(Class<?> c);
 }


### PR DESCRIPTION
This prevents a memory leak in the maintenance of per-class lists used to find affected `MemberName` objects in case of class redefinition.

This is https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/759 for JDK17. It's essentially the same change as in https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/759, https://github.com/ibmruntimes/openj9-openjdk-jdk22/pull/35, and https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/136, but the context lines in the diff are different