### PR TITLE
Add ExtendedMasterSecret support in SunPKCS11 provider

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -1125,6 +1125,10 @@ public final class SunPKCS11 extends AuthProvider {
                 m(CKM_SSL3_MASTER_KEY_DERIVE, CKM_TLS_MASTER_KEY_DERIVE,
                     CKM_SSL3_MASTER_KEY_DERIVE_DH,
                     CKM_TLS_MASTER_KEY_DERIVE_DH));
+        d(KG, "SunTlsExtendedMasterSecret",
+                    "sun.security.pkcs11.P11TlsMasterSecretGenerator",
+                m(CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE,
+                    CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH));
         d(KG, "SunTls12MasterSecret",
                 "sun.security.pkcs11.P11TlsMasterSecretGenerator",
             m(CKM_TLS12_MASTER_KEY_DERIVE, CKM_TLS12_MASTER_KEY_DERIVE_DH));
@@ -1508,7 +1512,8 @@ public final class SunPKCS11 extends AuthProvider {
                     return new P11TlsRsaPremasterSecretGenerator(
                         token, algorithm, mechanism);
                 } else if (algorithm == "SunTlsMasterSecret"
-                        || algorithm == "SunTls12MasterSecret") {
+                        || algorithm == "SunTls12MasterSecret"
+                        || algorithm == "SunTlsExtendedMasterSecret") {
                     return new P11TlsMasterSecretGenerator(
                         token, algorithm, mechanism);
                 } else if (algorithm == "SunTlsKeyMaterial"

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM.java
@@ -45,6 +45,12 @@
  *  POSSIBILITY  OF SUCH DAMAGE.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.pkcs11.wrapper;
 
 import java.math.BigInteger;
@@ -116,6 +122,10 @@ public class CK_MECHANISM {
     }
 
     public CK_MECHANISM(long mechanism, CK_TLS12_MASTER_KEY_DERIVE_PARAMS params) {
+        init(mechanism, params);
+    }
+
+    public CK_MECHANISM(long mechanism, CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS params) {
         init(mechanism, params);
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS.java
@@ -1,0 +1,105 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+package sun.security.pkcs11.wrapper;
+
+/**
+ * This class represents the necessary parameters required by the
+ * CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE and
+ * CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH mechanisms as defined
+ * in CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS structure.<p>
+ * <B>PKCS#11 structure:</B>
+ * <PRE>
+ * typedef struct CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS {
+ *     CK_MECHANISM_TYPE prfHashMechanism;
+ *     CK_BYTE_PTR pSessionHash;
+ *     CK_ULONG ulSessionHashLen;
+ *     CK_VERSION_PTR pVersion;
+ * } CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS;
+ * </PRE>
+ *
+ */
+public class CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS {
+
+    /**
+     * <B>PKCS#11:</B>
+     * <PRE>
+     *   CK_MECHANISM_TYPE prfHashMechanism;
+     * </PRE>
+     */
+    public final long prfHashMechanism;
+
+    /**
+     * <B>PKCS#11:</B>
+     * <PRE>
+     *   CK_BYTE_PTR pSessionHash;
+     * </PRE>
+     */
+    public final byte[] pSessionHash;
+
+    /**
+     * <B>PKCS#11:</B>
+     * <PRE>
+     *   CK_VERSION_PTR pVersion;
+     * </PRE>
+     */
+    public final CK_VERSION pVersion;
+
+    public CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS(
+            long prfHashMechanism, byte[] pSessionHash,
+            CK_VERSION pVersion) {
+        this.prfHashMechanism = prfHashMechanism;
+        this.pSessionHash = pSessionHash;
+        this.pVersion = pVersion;
+    }
+
+    /**
+     * Returns the string representation of
+     * CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS.
+     *
+     * @return the string representation of
+     * CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS
+     */
+    @Override
+    public String toString() {
+        StringBuilder buffer = new StringBuilder();
+
+        buffer.append(Constants.INDENT);
+        buffer.append("prfHashMechanism: ");
+        buffer.append(prfHashMechanism);
+        buffer.append(Constants.NEWLINE);
+
+        buffer.append(Constants.INDENT);
+        buffer.append("pSessionHash: ");
+        buffer.append(Functions.toHexString(pSessionHash));
+        buffer.append(Constants.NEWLINE);
+
+        buffer.append(Constants.INDENT);
+        buffer.append("pVersion: ");
+        buffer.append(pVersion);
+
+        return buffer.toString();
+    }
+
+}

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/Functions.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/Functions.java
@@ -45,6 +45,12 @@
  *  POSSIBILITY  OF SUCH DAMAGE.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.pkcs11.wrapper;
 
 import java.math.BigInteger;
@@ -1098,6 +1104,10 @@ public class Functions {
         addMech(CKM_VENDOR_DEFINED,             "CKM_VENDOR_DEFINED");
 
         addMech(CKM_NSS_TLS_PRF_GENERAL,        "CKM_NSS_TLS_PRF_GENERAL");
+        addMech(CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE,
+                                    "CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE");
+        addMech(CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH,
+                                    "CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH");
 
         addMech(PCKM_SECURERANDOM,              "SecureRandom");
         addMech(PCKM_KEYSTORE,                  "KeyStore");

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Constants.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11Constants.java
@@ -45,6 +45,12 @@
  *  POSSIBILITY  OF SUCH DAMAGE.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.pkcs11.wrapper;
 
 /**
@@ -999,6 +1005,10 @@ public interface PKCS11Constants {
 
     // NSS private
     public static final long  CKM_NSS_TLS_PRF_GENERAL        = 0x80000373L;
+    public static final long  CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE
+                                        /* (CKM_NSS + 25) */ = 0xCE534369L;
+    public static final long  CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH
+                                        /* (CKM_NSS + 26) */ = 0xCE53436AL;
 
     // internal ids for our pseudo mechanisms SecureRandom and KeyStore
     public static final long  PCKM_SECURERANDOM              = 0x7FFFFF20L;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_convert.c
@@ -46,6 +46,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * pkcs11wrapper.c
  * 18.05.2001
  *
@@ -604,6 +610,73 @@ jTls12MasterKeyDeriveParamToCKTls12MasterKeyDeriveParamPtr(JNIEnv *env,
     }
     return ckParamPtr;
 cleanup:
+    free(ckParamPtr);
+    return NULL;
+}
+
+/*
+ * Converts the Java CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS object to a
+ * CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS pointer.
+ *
+ * @param env - used to call JNI functions to get the Java classes and objects
+ * @param jParam - the Java CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS object to convert
+ * @param pLength - length of the allocated memory of the returned pointer
+ * @return pointer to the new CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS structure
+ */
+CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS_PTR
+jTlsExtendedMasterKeyDeriveParamToCKTlsExtendedMasterKeyDeriveParamPtr(JNIEnv *env,
+        jobject jParam, CK_ULONG *pLength)
+{
+    CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS_PTR ckParamPtr = NULL;
+    jclass jTlsExtendedMasterKeyDeriveParamsClass = NULL;
+    jfieldID fieldID = NULL;
+    jlong prfHashMechanism = 0L;
+    jobject pSessionHash = NULL;
+    if (NULL != pLength) {
+        *pLength = 0L;
+    }
+
+    // retrieve java values
+    jTlsExtendedMasterKeyDeriveParamsClass =
+            (*env)->FindClass(env, CLASS_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS);
+    if (NULL == jTlsExtendedMasterKeyDeriveParamsClass) {
+        return NULL;
+    }
+    fieldID = (*env)->GetFieldID(env,
+            jTlsExtendedMasterKeyDeriveParamsClass, "prfHashMechanism", "J");
+    if (NULL == fieldID) {
+        return NULL;
+    }
+    prfHashMechanism = (*env)->GetLongField(env, jParam, fieldID);
+    fieldID = (*env)->GetFieldID(env,
+            jTlsExtendedMasterKeyDeriveParamsClass, "pSessionHash", "[B");
+    if (NULL == fieldID) {
+        return NULL;
+    }
+    pSessionHash = (*env)->GetObjectField(env, jParam, fieldID);
+
+    // allocate memory for CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS pointer
+    ckParamPtr = calloc(1, sizeof(CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS));
+    if (NULL == ckParamPtr) {
+        throwOutOfMemoryError(env, 0);
+        return NULL;
+    }
+
+    // populate using java values
+    jByteArrayToCKByteArray(env, pSessionHash, &(ckParamPtr->pSessionHash),
+            &(ckParamPtr->ulSessionHashLen));
+    if ((*env)->ExceptionCheck(env)) {
+        goto cleanup;
+    }
+
+    ckParamPtr->prfHashMechanism = (CK_MECHANISM_TYPE) prfHashMechanism;
+
+    if (NULL != pLength) {
+        *pLength = sizeof(CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS);
+    }
+    return ckParamPtr;
+cleanup:
+    free(ckParamPtr->pSessionHash);
     free(ckParamPtr);
     return NULL;
 }
@@ -1484,6 +1557,11 @@ CK_VOID_PTR jMechParamToCKMechParamPtrSlow(JNIEnv *env, jobject jParam,
         case CKM_TLS12_MASTER_KEY_DERIVE_DH:
             ckpParamPtr = jTls12MasterKeyDeriveParamToCKTls12MasterKeyDeriveParamPtr(env, jParam,
                     ckpLength);
+            break;
+        case CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE:
+        case CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH:
+            ckpParamPtr = jTlsExtendedMasterKeyDeriveParamToCKTlsExtendedMasterKeyDeriveParamPtr(
+                    env, jParam, ckpLength);
             break;
         case CKM_TLS_PRF:
         case CKM_NSS_TLS_PRF_GENERAL:

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_keymgmt.c
@@ -45,6 +45,12 @@
  *  POSSIBILITY  OF SUCH DAMAGE.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "pkcs11wrapper.h"
 
 #include <stdio.h>
@@ -922,6 +928,9 @@ JNIEXPORT jlong JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1DeriveKey
     case CKM_TLS12_MASTER_KEY_DERIVE:
         tls12CopyBackClientVersion(env, ckpMechanism, jMechanism);
         break;
+    case CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE:
+        tlsEmsCopyBackClientVersion(env, ckpMechanism, jMechanism);
+        break;
     case CKM_SSL3_KEY_AND_MAC_DERIVE:
     case CKM_TLS_KEY_AND_MAC_DERIVE:
         /* we must copy back the unwrapped key info to the jMechanism object */
@@ -1038,6 +1047,24 @@ void tls12CopyBackClientVersion(JNIEnv *env, CK_MECHANISM_PTR ckpMechanism,
         copyBackClientVersion(env, ckpMechanism, jMechanism,
                 ckTLS12MasterKeyDeriveParams->pVersion,
                 CLASS_TLS12_MASTER_KEY_DERIVE_PARAMS);
+    }
+}
+
+/*
+ * Copy back the client version information from the native
+ * structure to the Java object. This is only used for
+ * CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE mechanism when used
+ * for deriving a key.
+ */
+void tlsEmsCopyBackClientVersion(JNIEnv *env, CK_MECHANISM_PTR ckpMechanism,
+        jobject jMechanism)
+{
+    CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS *ckTLSEmsMasterKeyDeriveParams
+            = (CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS *)ckpMechanism->pParameter;
+    if (NULL_PTR != ckTLSEmsMasterKeyDeriveParams) {
+        copyBackClientVersion(env, ckpMechanism, jMechanism,
+                ckTLSEmsMasterKeyDeriveParams->pVersion,
+                CLASS_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS);
     }
 }
 

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_util.c
@@ -45,6 +45,12 @@
  *  POSSIBILITY  OF SUCH DAMAGE.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "pkcs11wrapper.h"
 
 #include <stdio.h>
@@ -321,6 +327,7 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
      CK_SSL3_KEY_MAT_PARAMS* sslKmTmp;
      CK_TLS12_MASTER_KEY_DERIVE_PARAMS *tlsMkdTmp;
      CK_TLS12_KEY_MAT_PARAMS* tlsKmTmp;
+     CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS *tlsEmkdTmp = NULL;
 
      if (mechPtr != NULL) {
          TRACE2("DEBUG freeCKMechanismPtr: free pMech %p (mech 0x%lX)\n",
@@ -386,6 +393,13 @@ void freeCKMechanismPtr(CK_MECHANISM_PTR mechPtr) {
                      free(tlsMkdTmp->RandomInfo.pClientRandom);
                      free(tlsMkdTmp->RandomInfo.pServerRandom);
                      free(tlsMkdTmp->pVersion);
+                     break;
+                 case CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE:
+                 case CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH:
+                     tlsEmkdTmp = tmp;
+                     TRACE0("[ CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS ]\n");
+                     free(tlsEmkdTmp->pSessionHash);
+                     free(tlsEmkdTmp->pVersion);
                      break;
                  case CKM_TLS12_KEY_AND_MAC_DERIVE:
                      tlsKmTmp = tmp;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11t.h
@@ -5,6 +5,12 @@
  * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 /* Latest version of the specification:
  * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
  */
@@ -2172,6 +2178,16 @@ typedef struct CK_TLS12_MASTER_KEY_DERIVE_PARAMS {
 
 typedef CK_TLS12_MASTER_KEY_DERIVE_PARAMS CK_PTR \
         CK_TLS12_MASTER_KEY_DERIVE_PARAMS_PTR;
+
+typedef struct CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS {
+    CK_MECHANISM_TYPE prfHashMechanism;
+    CK_BYTE_PTR       pSessionHash;
+    CK_ULONG          ulSessionHashLen;
+    CK_VERSION_PTR    pVersion;
+} CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS;
+
+typedef CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS CK_PTR \
+        CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS_PTR;
 
 typedef struct CK_TLS12_KEY_MAT_PARAMS {
     CK_ULONG                ulMacSizeInBits;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
@@ -46,6 +46,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * pkcs11wrapper.h
  * 18.05.2001
  *
@@ -75,6 +81,8 @@
 #define CKA_NETSCAPE_TRUST_EMAIL_PROTECTION     (CKA_NETSCAPE_TRUST_BASE + 11)
 #define CKA_NETSCAPE_DB                         0xD5A0DB00
 #define CKM_NSS_TLS_PRF_GENERAL                 0x80000373
+#define CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE    (CKA_NETSCAPE_BASE + 25)
+#define CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH (CKA_NETSCAPE_BASE + 26)
 
 /*
 
@@ -292,6 +300,7 @@ void printDebug(const char *format, ...);
 // CLASS_SSL3_KEY_MAT_OUT is used by CLASS_SSL3_KEY_MAT_PARAMS and CK_TLS12_KEY_MAT_PARAMS
 #define CLASS_SSL3_MASTER_KEY_DERIVE_PARAMS "sun/security/pkcs11/wrapper/CK_SSL3_MASTER_KEY_DERIVE_PARAMS"
 #define CLASS_TLS12_MASTER_KEY_DERIVE_PARAMS "sun/security/pkcs11/wrapper/CK_TLS12_MASTER_KEY_DERIVE_PARAMS"
+#define CLASS_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS "sun/security/pkcs11/wrapper/CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS"
 #define CLASS_SSL3_KEY_MAT_PARAMS "sun/security/pkcs11/wrapper/CK_SSL3_KEY_MAT_PARAMS"
 #define CLASS_TLS12_KEY_MAT_PARAMS "sun/security/pkcs11/wrapper/CK_TLS12_KEY_MAT_PARAMS"
 #define CLASS_TLS_PRF_PARAMS "sun/security/pkcs11/wrapper/CK_TLS_PRF_PARAMS"
@@ -394,6 +403,7 @@ void copyBackPBEInitializationVector(JNIEnv *env, CK_MECHANISM *ckMechanism, job
 void copyBackSetUnwrappedKey(JNIEnv *env, CK_MECHANISM *ckMechanism, jobject jMechanism);
 void ssl3CopyBackClientVersion(JNIEnv *env, CK_MECHANISM *ckMechanism, jobject jMechanism);
 void tls12CopyBackClientVersion(JNIEnv *env, CK_MECHANISM *ckMechanism, jobject jMechanism);
+void tlsEmsCopyBackClientVersion(JNIEnv *env, CK_MECHANISM *ckMechanism, jobject jMechanism);
 void ssl3CopyBackKeyMatParams(JNIEnv *env, CK_MECHANISM *ckMechanism, jobject jMechanism);
 void tls12CopyBackKeyMatParams(JNIEnv *env, CK_MECHANISM *ckMechanism, jobject jMechanism);
 


### PR DESCRIPTION
This commit is for adding the ExtendedMasterSecret support in SunPKCS11 security provider.

This is a back-port PR from JDKNext PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/760