### PR TITLE
Remove redundant disabling of CDS feature

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -663,9 +663,6 @@ AC_DEFUN_ONCE([CUSTOM_LATE_HOOK],
   # Create the custom-spec.gmk
   AC_CONFIG_FILES([$OUTPUTDIR/custom-spec.gmk:$CLOSED_AUTOCONF_DIR/custom-spec.gmk.in])
 
-  # explicitly disable classlist generation
-  ENABLE_GENERATE_CLASSLIST=false
-
   if test "x$OPENJDK_BUILD_OS" = xwindows ; then
     OPENJ9_TOOL_DIR="$OUTPUTDIR/tools"
     AC_SUBST(OPENJ9_TOOL_DIR)


### PR DESCRIPTION
This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/778.