### PR TITLE
Get native EC key pointer during init through ECUtil instead of key impl

### DIFF
--- a/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECDSASignature.java
+++ b/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECDSASignature.java
@@ -102,14 +102,14 @@ abstract class NativeECDSASignature extends SignatureSpi {
     // private key, if initialized for signing
     private ECPrivateKey privateKey;
 
-    // private key impl, if initialized for signing
-    private ECPrivateKeyImpl privateKeyImpl;
+    // native private key pointer, if initialized for signing
+    private long nativePrivateKey;
 
     // public key, if initialized for verifying
     private ECPublicKey publicKey;
 
-    // public key impl, if initialized for verifying
-    private ECPublicKeyImpl publicKeyImpl;
+    // native public key pointer, if initialized for verifying
+    private long nativePublicKey;
 
     // signature parameters
     private ECParameterSpec sigParams;
@@ -118,7 +118,7 @@ abstract class NativeECDSASignature extends SignatureSpi {
     private final boolean p1363Format;
 
     // the Java implementation, if needed
-    private ECDSASignature javaImplementation;
+    ECDSASignature javaImplementation;
 
     /**
      * Constructs a new NativeECDSASignature.
@@ -182,51 +182,62 @@ abstract class NativeECDSASignature extends SignatureSpi {
         // Stores the precomputed message digest value.
         @Override
         protected void engineUpdate(byte b) throws SignatureException {
-            if (offset >= precomputedDigest.length) {
-                offset = RAW_ECDSA_MAX + 1;
-                return;
+            if (this.javaImplementation != null) {
+                this.javaImplementation.engineUpdate(b);
+            } else {
+                if (offset >= precomputedDigest.length) {
+                    offset = RAW_ECDSA_MAX + 1;
+                    return;
+                }
+                precomputedDigest[offset++] = b;
             }
-            precomputedDigest[offset++] = b;
         }
 
         // Stores the precomputed message digest value.
         @Override
         protected void engineUpdate(byte[] b, int off, int len)
         throws SignatureException {
-            if (offset >= precomputedDigest.length) {
-                offset = RAW_ECDSA_MAX + 1;
-                return;
+            if (this.javaImplementation != null) {
+                this.javaImplementation.engineUpdate(b, off, len);
+            } else {
+                if (offset >= precomputedDigest.length) {
+                    offset = RAW_ECDSA_MAX + 1;
+                    return;
+                }
+                System.arraycopy(b, off, precomputedDigest, offset, len);
+                offset += len;
             }
-            System.arraycopy(b, off, precomputedDigest, offset, len);
-            offset += len;
         }
 
         // Stores the precomputed message digest value.
         @Override
         protected void engineUpdate(ByteBuffer byteBuffer) {
-            int len = byteBuffer.remaining();
-            if (len <= 0) {
-                return;
+            if (this.javaImplementation != null) {
+                this.javaImplementation.engineUpdate(byteBuffer);
+            } else {
+                int len = byteBuffer.remaining();
+                if (len <= 0) {
+                    return;
+                }
+                if (len >= (precomputedDigest.length - offset)) {
+                    offset = RAW_ECDSA_MAX + 1;
+                    return;
+                }
+                byteBuffer.get(precomputedDigest, offset, len);
+                offset += len;
             }
-            if (len >= (precomputedDigest.length - offset)) {
-                offset = RAW_ECDSA_MAX + 1;
-                return;
-            }
-            byteBuffer.get(precomputedDigest, offset, len);
-            offset += len;
         }
 
         @Override
-        protected void resetDigest() {
+        void resetDigest() {
             offset = 0;
         }
 
         // Returns the precomputed message digest value.
         @Override
-        protected byte[] getDigestValue() throws SignatureException {
+        byte[] getDigestValue() throws SignatureException {
             if (offset > RAW_ECDSA_MAX) {
                 throw new SignatureException("Message digest is too long");
-
             }
             byte[] result = new byte[offset];
             System.arraycopy(precomputedDigest, 0, result, 0, offset);
@@ -391,16 +402,19 @@ abstract class NativeECDSASignature extends SignatureSpi {
         this.privateKey = null;
         resetDigest();
 
-        if (key instanceof ECPublicKeyImpl keyImpl) {
-            this.publicKeyImpl = keyImpl;
-            this.privateKeyImpl = null;
-            this.javaImplementation = null;
-            if (nativeCryptTrace) {
-                System.err.println("InitVerify: Using native crypto implementation for verifying signature.");
-            }
-        } else {
+        this.nativePublicKey = NativeECUtil.getPublicKeyNativePtr(key);
+        if (this.nativePublicKey == -1) {
             this.javaImplementation = getJavaInstance();
             this.javaImplementation.engineInitVerify(publicKey);
+            if (nativeCryptTrace) {
+                System.err.println("InitVerify: Could not create a pointer to a native key."
+                        + " Using Java implementation.");
+            }
+            return;
+        }
+        this.javaImplementation = null;
+        if (nativeCryptTrace) {
+            System.err.println("InitVerify: Keys were successfully converted to native OpenSSL format.");
         }
     }
 
@@ -449,23 +463,26 @@ abstract class NativeECDSASignature extends SignatureSpi {
         this.random = random;
         resetDigest();
 
-        if (key instanceof ECPrivateKeyImpl keyImpl) {
-            this.publicKeyImpl = null;
-            this.privateKeyImpl = keyImpl;
-            this.javaImplementation = null;
-            if (nativeCryptTrace) {
-                System.err.println("InitSign: Using native crypto implementation for verifying signature.");
-            }
-        } else {
+        this.nativePrivateKey = NativeECUtil.getPrivateKeyNativePtr(key);
+        if (this.nativePrivateKey == -1) {
             this.javaImplementation = getJavaInstance();
             this.javaImplementation.engineInitSign(privateKey, random);
+            if (nativeCryptTrace) {
+                System.err.println("InitSign: Could not create a pointer to a native key."
+                        + " Using Java implementation.");
+            }
+            return;
+        }
+        this.javaImplementation = null;
+        if (nativeCryptTrace) {
+            System.err.println("InitSign: Keys were successfully converted to native OpenSSL format.");
         }
     }
 
     /**
      * Resets the message digest if needed.
      */
-    protected void resetDigest() {
+    void resetDigest() {
         if (needsReset) {
             if (messageDigest != null) {
                 messageDigest.reset();
@@ -477,7 +494,7 @@ abstract class NativeECDSASignature extends SignatureSpi {
     /**
      * Returns the message digest value.
      */
-    protected byte[] getDigestValue() throws SignatureException {
+    byte[] getDigestValue() throws SignatureException {
         needsReset = false;
         return messageDigest.digest();
     }
@@ -537,7 +554,6 @@ abstract class NativeECDSASignature extends SignatureSpi {
             return this.javaImplementation.engineSign();
         }
 
-        long nativePrivateKey = privateKeyImpl.getNativePtr();
         byte[] digest = getDigestValue();
         int digestLen = digest.length;
         ECParameterSpec params = privateKey.getParams();
@@ -546,13 +562,6 @@ abstract class NativeECDSASignature extends SignatureSpi {
 
         ECDSAOperations.forParameters(params)
                 .orElseThrow(() -> new SignatureException("Curve not supported: " + params));
-
-        if (nativePrivateKey == -1) {
-            throw new ProviderException("Keys could not be converted to native OpenSSL format");
-        }
-        if (nativeCryptTrace) {
-            System.err.println("Sign: Keys were successfully converted to native OpenSSL format.");
-        }
 
         if (nativeCrypto == null) {
             nativeCrypto = NativeCrypto.getNativeCrypto();
@@ -602,14 +611,6 @@ abstract class NativeECDSASignature extends SignatureSpi {
             if (!ops.getEcOperations().checkOrder(w)) {
                 return false;
             }
-        }
-
-        long nativePublicKey = publicKeyImpl.getNativePtr();
-        if (nativePublicKey == -1) {
-            throw new ProviderException("Could not convert keys to native format");
-        }
-        if (nativeCryptTrace) {
-            System.err.println("Verify: Keys were successfully converted to native OpenSSL format.");
         }
 
         if (nativeCrypto == null) {

--- a/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECUtil.java
+++ b/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECUtil.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.math.BigInteger;
 import java.security.ProviderException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.ECPoint;
@@ -157,5 +159,62 @@ public final class NativeECUtil {
                                        gy, gy.length,
                                        n, n.length,
                                        h, h.length);
+    }
+
+    /**
+     * Returns the native pointer for the provided EC public key.
+     *
+     * @param key   the EC public key
+     * @return      the native EC public key context pointer or -1 on error
+     */
+    static long getPublicKeyNativePtr(ECPublicKey key) {
+        synchronized (key) {
+            long nativePointer = encodeGroup(key.getParams());
+            if (nativePointer != -1) {
+                try {
+                    byte[] x = key.getW().getAffineX().toByteArray();
+                    byte[] y = key.getW().getAffineY().toByteArray();
+                    int fieldType = NativeCrypto.ECField_Fp;
+                    if (key.getParams().getCurve().getField() instanceof ECFieldF2m) {
+                        fieldType = NativeCrypto.ECField_F2m;
+                    }
+                    if (nativeCrypto.ECCreatePublicKey(nativePointer, x, x.length, y, y.length, fieldType) == -1) {
+                        nativeCrypto.ECDestroyKey(nativePointer);
+                        nativePointer = -1;
+                    }
+                } finally {
+                    if (nativePointer != -1) {
+                        nativeCrypto.createECKeyCleaner(key, nativePointer);
+                    }
+                }
+            }
+            return nativePointer;
+        }
+    }
+
+    /**
+     * Returns the native pointer for the provided EC private key.
+     *
+     * @param key   the EC private key
+     * @return      the native EC private key context pointer or -1 on error
+     */
+    static long getPrivateKeyNativePtr(ECPrivateKey key) {
+        synchronized (key) {
+            long nativePointer = encodeGroup(key.getParams());
+            if (nativePointer != -1) {
+                try {
+                    byte[] value = key.getS().toByteArray();
+                    if (nativeCrypto.ECCreatePrivateKey(nativePointer, value, value.length) == -1) {
+                        nativeCrypto.ECDestroyKey(nativePointer);
+                        nativePointer = -1;
+                    }
+                } finally {
+                    if (nativePointer != -1) {
+                        nativeCrypto.createECKeyCleaner(key, nativePointer);
+                    }
+                }
+            }
+            return nativePointer;
+        }
     }
 }

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPrivateKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPrivateKeyImpl.java
@@ -23,12 +23,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
- * ===========================================================================
- */
-
 package sun.security.ec;
 
 import java.io.IOException;
@@ -40,8 +34,6 @@ import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
 import java.util.Arrays;
-
-import jdk.crypto.jniprovider.NativeCrypto;
 
 import sun.security.util.*;
 import sun.security.x509.AlgorithmId;
@@ -74,12 +66,10 @@ public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
 
     @java.io.Serial
     private static final long serialVersionUID = 88695385615075129L;
-    private static NativeCrypto nativeCrypto;
 
     private BigInteger s;       // private value
     private byte[] arrayS;      // private value as a little-endian array
     private ECParameterSpec params;
-    private long nativeECKey;
 
     /**
      * Construct a key from its encoding. Called by the ECKeyFactory.
@@ -233,37 +223,5 @@ public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
             throws IOException, ClassNotFoundException {
         throw new InvalidObjectException(
                 "ECPrivateKeyImpl keys are not directly deserializable");
-    }
-
-    /**
-     * Returns the native EC public key context pointer.
-     * @return the native EC public key context pointer or -1 on error
-     */
-    long getNativePtr() {
-        if (this.nativeECKey == 0x0) {
-            synchronized (this) {
-                if (this.nativeECKey == 0x0) {
-                    if (nativeCrypto == null) {
-                        nativeCrypto = NativeCrypto.getNativeCrypto();
-                    }
-                    long nativePointer = NativeECUtil.encodeGroup(this.params);
-                    try {
-                        if (nativePointer != -1) {
-                            byte[] value = this.getS().toByteArray();
-                            if (nativeCrypto.ECCreatePrivateKey(nativePointer, value, value.length) == -1) {
-                                nativeCrypto.ECDestroyKey(nativePointer);
-                                nativePointer = -1;
-                            }
-                        }
-                    } finally {
-                        if (nativePointer != -1) {
-                            nativeCrypto.createECKeyCleaner(this, nativePointer);
-                        }
-                    }
-                    this.nativeECKey = nativePointer;
-                }
-            }
-        }
-        return this.nativeECKey;
     }
 }

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPublicKeyImpl.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/ECPublicKeyImpl.java
@@ -23,24 +23,15 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
- * ===========================================================================
- */
-
 package sun.security.ec;
 
 import java.io.IOException;
-import java.math.BigInteger;
 
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
-
-import jdk.crypto.jniprovider.NativeCrypto;
 
 import sun.security.util.ECParameters;
 import sun.security.util.ECUtil;
@@ -57,11 +48,9 @@ public final class ECPublicKeyImpl extends X509Key implements ECPublicKey {
 
     @java.io.Serial
     private static final long serialVersionUID = -2462037275160462289L;
-    private static NativeCrypto nativeCrypto;
 
     private ECPoint w;
     private ECParameterSpec params;
-    private long nativeECKey;
 
     /**
      * Construct a key from its components. Used by the
@@ -158,42 +147,5 @@ public final class ECPublicKeyImpl extends X509Key implements ECPublicKey {
             throws IOException, ClassNotFoundException {
         throw new InvalidObjectException(
                 "ECPublicKeyImpl keys are not directly deserializable");
-    }
-
-    /**
-     * Returns the native EC public key context pointer.
-     * @return the native EC public key context pointer or -1 on error
-     */
-    long getNativePtr() {
-        if (this.nativeECKey == 0x0) {
-            synchronized (this) {
-                if (this.nativeECKey == 0x0) {
-                    if (nativeCrypto == null) {
-                        nativeCrypto = NativeCrypto.getNativeCrypto();
-                    }
-                    long nativePointer = NativeECUtil.encodeGroup(this.params);
-                    try {
-                        if (nativePointer != -1) {
-                            byte[] x = this.w.getAffineX().toByteArray();
-                            byte[] y = this.w.getAffineY().toByteArray();
-                            int fieldType = NativeCrypto.ECField_Fp;
-                            if (this.params.getCurve().getField() instanceof ECFieldF2m) {
-                                fieldType = NativeCrypto.ECField_F2m;
-                            }
-                            if (nativeCrypto.ECCreatePublicKey(nativePointer, x, x.length, y, y.length, fieldType) == -1) {
-                                nativeCrypto.ECDestroyKey(nativePointer);
-                                nativePointer = -1;
-                            }
-                        }
-                    } finally {
-                        if (nativePointer != -1) {
-                            nativeCrypto.createECKeyCleaner(this, nativePointer);
-                        }
-                    }
-                    this.nativeECKey = nativePointer;
-                }
-            }
-        }
-        return this.nativeECKey;
     }
 }


### PR DESCRIPTION
The acquisition of a native pointer for an EC key, private or public, is being moved to the ECUtil, instead of the implementation classes of said keys. This allows use of interop keys, rather than just keys coming from SunEC.

The methods to get the pointers to the native keys are called during the initialization phases, to discover the possibility of not being able to utilize the native code and revert to the Java implementation early.

The engineUpdate() methods of the RawECDSA subclass are, also, updated to use the java implementation, if one has been initialized.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/792

Signed-off by: Kostas Tsiounis <kostas.tsiounis@ibm.com>