### PR TITLE
Support brainpoolP512r1 TLS 1.3 RFC 8734

### DIFF
--- a/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECKeyPairGenerator.java
+++ b/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECKeyPairGenerator.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -51,10 +51,10 @@ import java.security.spec.ECField;
 import java.security.spec.ECFieldFp;
 import java.security.spec.ECFieldF2m;
 import java.security.spec.InvalidParameterSpecException;
-import java.util.Arrays;
 
 import jdk.crypto.jniprovider.NativeCrypto;
 
+import sun.security.action.GetPropertyAction;
 import sun.security.ec.point.*;
 import sun.security.jca.JCAUtil;
 import sun.security.provider.Sun;
@@ -88,6 +88,8 @@ public final class NativeECKeyPairGenerator extends KeyPairGeneratorSpi {
 
     /* the java implementation, initialized if needed */
     private ECKeyPairGenerator javaImplementation;
+
+    private static final boolean isAIX = "AIX".equals(GetPropertyAction.privilegedGetProperty("os.name"));
 
     /**
      * Constructs a new NativeECKeyPairGenerator.
@@ -138,6 +140,23 @@ public final class NativeECKeyPairGenerator extends KeyPairGeneratorSpi {
         this.random = random;
 
         this.curve = NativeECUtil.getCurveName(this.params);
+
+        /*
+         * Only brainpoolP512r1 curve is supported on AIX. Other curves are disabled
+         * for use with OpenSSL on AIX due to performance regressions observed. This
+         * method does not specify brainpool so use the Java implementation for
+         * ECKeyPairGenerator instead.
+         */
+        if (isAIX) {
+            /* Disabling OpenSSL usage on AIX due to performance regression observed. */
+            if (nativeCryptTrace) {
+                System.err.println("Not using OpenSSL integration on AIX.");
+            }
+            this.javaImplementation = new ECKeyPairGenerator();
+            this.javaImplementation.initialize(this.keySize, this.random);
+            return;
+        }
+
         if ((this.curve != null) && NativeECUtil.isCurveSupported(this.curve, this.params)) {
             this.javaImplementation = null;
         } else {
@@ -191,14 +210,27 @@ public final class NativeECKeyPairGenerator extends KeyPairGeneratorSpi {
                 "ECParameterSpec or ECGenParameterSpec required for EC");
         }
 
-        // Not all known curves are supported by the native implementation
-        ECKeyPairGenerator.ensureCurveIsSupported(ecSpec);
+        // Not all known curves are supported by the native implementation.
+        if (!NativeECUtil.isBrainpoolP512r1(ecSpec)) {
+            ECKeyPairGenerator.ensureCurveIsSupported(ecSpec);
+        }
+
         this.params = ecSpec;
 
         this.keySize = ecSpec.getCurve().getField().getFieldSize();
         this.random = random;
 
         this.curve = NativeECUtil.getCurveName(this.params);
+
+        /* Disabling OpenSSL usage on AIX due to performance regression observed. */
+        if (isAIX && !NativeECUtil.isBrainpoolP512r1(ecSpec)) {
+            if (nativeCryptTrace) {
+                System.err.println("Not using OpenSSL integration on AIX, only curve brainpoolP512r1 supported.");
+            }
+            this.initializeJavaImplementation();
+            return;
+        }
+
         if ((this.curve != null) && (NativeECUtil.isCurveSupported(this.curve, this.params))) {
             this.javaImplementation = null;
         } else {

--- a/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECUtil.java
+++ b/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECUtil.java
@@ -47,6 +47,7 @@ import java.security.spec.ECFieldF2m;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECGenParameterSpec;
 import java.security.AlgorithmParameters;
+import sun.security.util.CurveDB;
 import sun.security.util.NamedCurve;
 
 import jdk.crypto.jniprovider.NativeCrypto;
@@ -216,5 +217,18 @@ public final class NativeECUtil {
             }
             return nativePointer;
         }
+    }
+
+    static boolean isBrainpoolP512r1(ECParameterSpec name) {
+        NamedCurve curve = CurveDB.lookup(name);
+        if (curve != null) {
+            String[] nameAndAliases = curve.getNameAndAliases();
+            for (String nameOrAlias : nameAndAliases) {
+                if ("brainpoolP512r1".equalsIgnoreCase(nameOrAlias)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
+++ b/src/java.base/share/classes/sun/security/ssl/NamedGroup.java
@@ -22,6 +22,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 package sun.security.ssl;
 
 import javax.crypto.spec.DHParameterSpec;
@@ -179,6 +185,12 @@ enum NamedGroup {
             NamedGroupSpec.NAMED_GROUP_ECDHE,
             ProtocolVersion.PROTOCOLS_TO_13,
             CurveDB.lookup("secp521r1")),
+
+    // Brainpool named curve definition as per RFC 8734.
+    BRAINPOOLP512_R1TLS13(0x0021, "brainpoolP512r1tls13",
+            NamedGroupSpec.NAMED_GROUP_ECDHE,
+            ProtocolVersion.PROTOCOLS_OF_13,
+            CurveDB.lookup("brainpoolP512r1")),
 
     // x25519 and x448 (RFC 8422/8446)
     X25519(0x001D, "x25519",

--- a/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
+++ b/src/jdk.crypto.ec/share/classes/sun/security/ec/SunEC.java
@@ -257,11 +257,6 @@ public final class SunEC extends Provider {
                                 if (nativeCryptTrace) {
                                     System.err.println("EC KeyPair Generation - Not using OpenSSL integration due to older version of OpenSSL (<1.1.0).");
                                 }
-                            } else if (isAIX) {
-                                /* Disabling OpenSSL usage on AIX due to perfomance regression observed. */
-                                if (nativeCryptTrace) {
-                                    System.err.println("EC KeyPair Generation - Not using OpenSSL integration on AIX.");
-                                }
                             } else {
                                 if (nativeCryptTrace) {
                                     System.err.println("EC KeyPair Generation - Using OpenSSL integration.");

--- a/test/jdk/javax/net/ssl/TLSCommon/TLSTest.java
+++ b/test/jdk/javax/net/ssl/TLSCommon/TLSTest.java
@@ -22,6 +22,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -53,6 +59,11 @@ import javax.net.ssl.TrustManagerFactory;
  * @bug 8205111
  * @summary Test TLS with different types of supported keys.
  * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha1 TLS_AES_128_GCM_SHA256
+ * @run main/othervm
+ *      -Djdk.tls.client.SignatureSchemes=ecdsa_brainpoolP512r1tls13_sha512
+ *      -Djdk.tls.namedGroups=brainpoolP512r1tls13
+ *      -Djdk.tls.server.SignatureSchemes=ecdsa_brainpoolP512r1tls13_sha512
+ *      TLSTest TLSv1.3 ecdsa_brainpoolP512r1_sha512 TLS_AES_128_GCM_SHA256
  * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha256 TLS_AES_128_GCM_SHA256
  * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha384 TLS_AES_128_GCM_SHA256
  * @run main/othervm TLSTest TLSv1.3 rsa_pkcs1_sha512 TLS_AES_128_GCM_SHA256
@@ -454,6 +465,31 @@ public class TLSTest {
                 "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgyJJNI8eqYVKcCshG\n"
                 + "t89mrRZ1jMeD8fAbgijAG7WfgtGhRANCAAR6LMO6lBGdmpo87XTjtA2vsXvq1kd8\n"
                 + "ktaIGEdCrA8BKk0A30LW8SY5Be29ScYu8d+IjQ3X/fpblrVh/64pOgQz"
+        ),
+        ecdsa_brainpoolP512r1_sha512(
+            "EC",
+
+            "-----BEGIN CERTIFICATE-----\n"
+            + "MIICRzCCAaygAwIBAgIIRwv8F2wpI+gwCgYIKoZIzj0EAwQwVjELMAkGA1UEBhMC\n"
+            + "VVMxCzAJBgNVBAgTAk5ZMQ0wCwYDVQQHEwRUZXN0MQ0wCwYDVQQKEwRUZXN0MQ0w\n"
+            + "CwYDVQQLEwRUZXN0MQ0wCwYDVQQDEwRUZXN0MB4XDTI0MDUwOTE3MzEwOVoXDTI1\n"
+            + "MDUwOTE3MzEwOVowVjELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAk5ZMQ0wCwYDVQQH\n"
+            + "EwRUZXN0MQ0wCwYDVQQKEwRUZXN0MQ0wCwYDVQQLEwRUZXN0MQ0wCwYDVQQDEwRU\n"
+            + "ZXN0MIGbMBQGByqGSM49AgEGCSskAwMCCAEBDQOBggAEKW44Kx0jbGqLa0YqK2zc\n"
+            + "6/95LIgJseQjKAE5bxyr92hnGwXQV4Xpu9ncZKFEPx1XJpfeb68+ds6CF4oRI8cf\n"
+            + "YR3KEXazpDOZ6EoM8qYawch61QZlJmfBw9+SzDI26Kr7yOphqi8WTO1X6LWRjCTT\n"
+            + "KpBiIfWcIBw25G1NNDM26/ujITAfMB0GA1UdDgQWBBSQ5LauX//LL5I3Re1m5Z92\n"
+            + "9iVd3jAKBggqhkjOPQQDBAOBiAAwgYQCQHIcs0OAiPOjknW4scGqxBkOTgdjOaEE\n"
+            + "ts0Q6O0kzOYYBYEjsyNTWAO6cIZjXovvdwbs0j+YXaPV6bh0aerKXMACQFVMMJJF\n"
+            + "tDZNP+FsegcRWA14Jx+aeNIRWeEa7cVZ9lRzf5/IsFS9mQnXpyI8oQStnNncqyLR\n"
+            + "RIW0f9OAnOvzApQ=\n"
+            + "-----END CERTIFICATE-----\n",
+            //
+            // Private key.
+            //
+            "MGICAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQENBEcwRQIBAQRAgPx92Cu2UnmeC/NG\n"
+            + "KdwrYso1y3MHfY8UbcvuC/POxDqvrYsaSqBBWq8uSFlgRAwFXhdMJDzF9jGbaw79\n"
+            + "gNzowQ==\n"
         ),
         rsa_pss_pss_sha256(
                 "RSASSA-PSS",

--- a/test/jdk/javax/net/ssl/TLSv13/ClientHelloKeyShares.java
+++ b/test/jdk/javax/net/ssl/TLSv13/ClientHelloKeyShares.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 // SunJSSE does not support dynamic system properties, no way to re-use
 // system properties in samevm/agentvm mode.  For further debugging output
 // set the -Djavax.net.debug=ssl:handshake property on the @run lines.
@@ -31,6 +37,7 @@
  * @summary Use two key share entries
  * @run main/othervm ClientHelloKeyShares 29 23
  * @run main/othervm -Djdk.tls.namedGroups=secp384r1,secp521r1,x448,ffdhe2048 ClientHelloKeyShares 24 30
+ * @run main/othervm -Djdk.tls.namedGroups=brainpoolP512r1tls13,x448,ffdhe2048 ClientHelloKeyShares 33 30
  * @run main/othervm -Djdk.tls.namedGroups=sect163k1,sect163r1,x25519 ClientHelloKeyShares 29
  * @run main/othervm -Djdk.tls.namedGroups=sect163k1,sect163r1,secp256r1 ClientHelloKeyShares 23
  * @run main/othervm -Djdk.tls.namedGroups=sect163k1,sect163r1,ffdhe2048,ffdhe3072,ffdhe4096 ClientHelloKeyShares 256

--- a/test/jdk/sun/security/pkcs11/ec/TestECDSA.java
+++ b/test/jdk/sun/security/pkcs11/ec/TestECDSA.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 6405536 8042967
  * @summary basic test of SHA1withECDSA and NONEwithECDSA signing/verifying
@@ -75,6 +81,12 @@ public class TestECDSA extends PKCS11Test {
     private final static String priv571 =
 "30:65:02:01:00:30:10:06:07:2a:86:48:ce:3d:02:01:06:05:2b:81:04:00:26:04:4e:30:4c:02:01:01:04:47:cb:b0:84:c9:5e:d5:bb:d1:27:6b:8e:36:51:5d:ed:8d:0f:69:f4:b0:34:c2:4f:e8:e5:a5:3a:a9:38:52:ca:b6:b2:c7:04:8b:09:b7:ac:68:11:00:22:7a:d7:4b:11:77:0f:3f:ba:72:e5:8b:a7:4d:82:8e:a7:d9:55:cf:60:9c:23:f4:a7:22:47:b8:3e";
 
+    // keypair using brainpoolP512r1
+    private final static String pubBrainpoolP512 =
+"30:81:9b:30:14:06:07:2a:86:48:ce:3d:02:01:06:09:2b:24:03:03:02:08:01:01:0d:03:81:82:00:04:3c:ae:c6:f8:c9:71:51:59:d1:7d:bd:0d:b9:76:23:25:df:2c:4e:b4:b1:6e:22:79:5b:97:1b:60:0b:3e:87:f3:9f:af:44:84:55:c3:64:6b:1e:dd:4d:12:27:81:31:07:21:4e:b0:a5:73:3c:91:11:8f:ad:f4:74:12:fd:dc:74:76:c6:44:b2:57:d6:c4:ed:99:71:c8:46:6c:b7:f7:a7:ef:36:5c:7d:6c:4a:a3:6f:f9:4b:0a:ea:34:58:80:05:ac:15:ae:82:84:f2:f3:c6:85:2c:5a:ae:45:4b:64:4c:4f:ef:50:a5:6b:84:fd:52:11:08:09:09:fb:b5:1a:5b";
+    private final static String privBrainpoolP512 =
+"30:81:ec:02:01:00:30:14:06:07:2a:86:48:ce:3d:02:01:06:09:2b:24:03:03:02:08:01:01:0d:04:81:d0:30:81:cd:02:01:01:04:40:1d:dc:04:b7:49:a9:2f:45:96:cb:d9:a0:39:ba:5a:af:a9:1b:7e:a3:81:4c:fa:be:b7:a9:94:96:5d:7c:54:94:03:5d:6a:07:d1:3d:6e:ca:00:80:9d:0a:90:2c:69:ac:86:5b:d7:13:f8:f2:6c:c6:97:6f:e5:f5:cc:65:9e:f4:a1:81:85:03:81:82:00:04:3c:ae:c6:f8:c9:71:51:59:d1:7d:bd:0d:b9:76:23:25:df:2c:4e:b4:b1:6e:22:79:5b:97:1b:60:0b:3e:87:f3:9f:af:44:84:55:c3:64:6b:1e:dd:4d:12:27:81:31:07:21:4e:b0:a5:73:3c:91:11:8f:ad:f4:74:12:fd:dc:74:76:c6:44:b2:57:d6:c4:ed:99:71:c8:46:6c:b7:f7:a7:ef:36:5c:7d:6c:4a:a3:6f:f9:4b:0a:ea:34:58:80:05:ac:15:ae:82:84:f2:f3:c6:85:2c:5a:ae:45:4b:64:4c:4f:ef:50:a5:6b:84:fd:52:11:08:09:09:fb:b5:1a:5b";
+
     // data for test 1, original and SHA-1 hashed
     private final static byte[] data1Raw = b("0102030405060708090a0b0c0d0e0f10111213");
     private final static byte[] data1SHA = b("00:e2:5f:c9:1c:8f:d6:8c:6a:dc:c6:bd:f0:46:60:5e:a2:cd:8d:ad");
@@ -84,6 +96,7 @@ public class TestECDSA extends PKCS11Test {
     private final static byte[] sig163 = b("30:2d:02:15:02:8d:aa:95:06:f4:4f:fa:44:59:ec:4b:cb:86:59:8c:1f:25:36:64:f5:02:14:6b:d1:ea:82:ed:0c:2a:19:a1:c5:fa:d6:05:78:4b:eb:bf:83:d5:fa");
     private final static byte[] sig521 = b("30:81:87:02:42:01:32:a5:be:dd:fb:c3:07:66:01:48:0a:12:dd:ae:e7:4d:cf:c2:69:ba:37:bc:fb:47:f3:5b:0f:9e:80:2c:c4:c4:40:6f:82:a1:25:39:65:4f:37:9c:b2:59:e0:4c:d6:a2:63:27:b4:fd:fd:ca:72:c8:de:c9:38:8b:02:87:bf:13:d8:02:41:0b:03:0f:3f:f9:cc:93:cb:f5:30:4d:d2:23:f3:cb:3d:b8:ee:8b:76:96:b9:4b:91:2e:b3:8e:26:47:a9:56:89:01:3a:5e:92:79:8f:00:f0:1c:a9:32:f7:70:e2:18:71:35:2c:4d:b7:68:84:2f:56:49:86:eb:96:5d:82:31:a2:de");
     private final static byte[] sig571 = b("30:81:94:02:48:01:4b:81:77:93:cf:bc:98:26:4c:0d:e2:18:f0:d5:b0:bd:b0:a4:a3:b3:8e:1d:3f:7b:21:5d:65:08:42:f7:e6:7e:87:a0:a9:62:9a:79:b0:9d:d6:d6:f0:10:3b:7c:54:aa:cd:f0:d0:5e:5b:f8:f4:36:ec:64:cf:b4:e0:4e:03:db:12:96:e2:25:0c:3b:01:02:48:01:0d:9e:1d:3b:bf:7d:c6:e1:ea:54:92:c4:6b:95:bb:5b:c9:2b:ea:f2:e6:bf:8d:b2:4f:c4:0e:12:f9:35:70:a3:ed:49:f1:11:97:07:a0:05:16:f0:f5:01:8d:15:53:4d:df:51:a0:cf:bc:f0:9f:01:99:e5:2e:e4:9d:02:05:0e:7f:fa:b5:c3:20:eb:5e");
+    private final static byte[] sigBrainpool512 = b("30:81:85:02:40:05:92:EC:9C:7B:60:30:0F:54:82:6B:A1:94:CF:16:20:C5:00:08:2F:C6:99:FD:4A:53:4D:EB:B8:74:15:A1:24:08:DE:F1:8D:70:9C:F3:2C:63:CE:37:B6:21:12:5A:82:60:7A:8F:A2:1C:DE:22:DD:5D:D9:77:ED:08:80:D0:6C:02:41:00:A8:DB:47:9B:53:FA:4B:B0:4D:A1:EE:C7:AE:9D:FB:CE:82:4E:8D:C4:32:A4:8A:C1:8A:31:FD:F3:D4:D8:2F:0D:5F:91:C6:A7:E7:9C:3C:2E:B3:22:EF:CB:77:DE:AC:3F:C5:41:01:06:D8:04:46:A1:16:88:5D:5B:C2:38:47:AC");
 
     // data for test 2 (invalid signatures)
     private final static byte[] data2Raw = {};
@@ -166,6 +179,17 @@ public class TestECDSA extends PKCS11Test {
             test(provider, pub571, priv571, sig571);
         }
         test(provider, pub521, priv521, sig521);
+
+        // This test is known to be executed in two ways:
+        // 1. Direct execution of this test for testing sun.security.pkcs11
+        // functionality. Skip brainpoolP512r1 tests in this case since the PKCS11
+        // provider does not support them.
+        // 2. Running the testcase in sun/security/ec. Expect brainpoolP512r1
+        // curve to be present and execute the brainpoolP512r1 specific test.
+        if (provider.getName().equalsIgnoreCase("SunEC")) {
+            System.out.println("Running brainpool curve tests with SunEC provider.");
+            test(provider, pubBrainpoolP512, privBrainpoolP512, sigBrainpool512);
+         }
 
         long stop = System.currentTimeMillis();
         System.out.println("All tests passed (" + (stop - start) + " ms).");


### PR DESCRIPTION
This update supports both the `ecdsa_brainpoolP512r1tls13_sha512` signature scheme and `brainpoolP512r1tls13` key exchange mechanisms defined in `RFC 8734` using `openssl`.

The `NativeECDHKeyAgreement` class was enhanced to allow for a key exchange to take place using the EC named curve `brainpoolP512r1`. This functionality can be enabled by configuring the named group `brainpoolP512r1tls13`.

The `NativeECDSASignature` class was enhanced to allow for `ECDSA` `brainpoolP512r1` signatures to be routed to openssl for execution.

The `NativeECKeyPairGenerator` was enhanced to allow for `brainpoolP512r1` based keys to be generated with openssl.

Both the `ecdsa_brainpoolP512r1tls13_sha512` signature scheme and `brainpoolP512r1tls13` key exchange mechanism are optionally configured and not enabled by default.

Tests were added to exercise both the signature scheme and key exchange along with sign and verify using the `brainpoolP512r1` named curve.