### PR TITLE
JDK17 adds OpenJ9 properties vm.flagless

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -40,6 +40,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
             map.put("vm.bits", vmBits());
             map.put("vm.compiler2.enabled", "false");
             map.put("vm.debug", "false");
+            map.put("vm.flagless", "true");
             map.put("vm.gc.G1", "false");
             map.put("vm.gc.Parallel", "false");
             map.put("vm.gc.Serial", "false");


### PR DESCRIPTION
JDK17 adds OpenJ9 properties `vm.flagless`

Set it to `true`.

closes https://github.com/eclipse-openj9/openj9/issues/19980

Signed-off-by: Jason Feng <fengj@ca.ibm.com>