### PR TITLE
Add DebugOptions test into OpenJCEPlusFIPS ProblemList

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -911,6 +911,7 @@ sun/security/tools/keytool/fakecacerts/TrustedCRL.java https://github.com/ibmrun
 sun/security/tools/keytool/fakecacerts/TrustedCert.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/321 linux-x64,linux-ppc64le,linux-s390x,aix-all
 sun/security/tools/keytool/fakegen/DefaultSignatureAlgorithm.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/321 linux-x64,linux-ppc64le,linux-s390x,aix-all
 sun/security/tools/keytool/fakegen/PSS.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/321 linux-x64,linux-ppc64le,linux-s390x,aix-all
+sun/security/util/Debug/DebugOptions.java https://github.com/eclipse-openj9/openj9/issues/19977 aix-all,linux-ppc64le,linux-s390x,linux-x64,windows-all
 sun/security/util/HostnameMatcher/NullHostnameCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/321 linux-x64,linux-ppc64le,linux-s390x,aix-all
 sun/security/validator/EndEntityExtensionCheck.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/321 linux-x64,linux-ppc64le,linux-s390x,aix-all
 sun/security/validator/certreplace.sh https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/321 linux-x64,linux-ppc64le,linux-s390x,aix-all


### PR DESCRIPTION
This PR is for updating the OpenJCEPlusFIPS ignore list to exclude the sun/security/util/Debug/DebugOptions.java test, which is not designed for testing the security properties output for OpenJCEPlusFIPS profile.