### PR TITLE
Avoid hang in preClose method during dup2 system call

### DIFF
--- a/closed/src/java.base/share/classes/sun/net/util/AIX.java
+++ b/closed/src/java.base/share/classes/sun/net/util/AIX.java
@@ -1,0 +1,31 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+package sun.net.util;
+
+import sun.security.action.GetPropertyAction;
+
+public final class AIX {
+    // Flag indicating whether the operating system is AIX.
+    public static final boolean isAIX = "AIX".equals(GetPropertyAction.privilegedGetProperty("os.name"));
+}

--- a/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.nio.ch;
 
 import java.io.FileDescriptor;
@@ -72,6 +78,7 @@ import java.util.function.Consumer;
 import jdk.internal.ref.CleanerFactory;
 import sun.net.ResourceManager;
 import sun.net.ext.ExtendedSocketOptions;
+import sun.net.util.AIX;
 import sun.net.util.IPAddressUtil;
 
 /**
@@ -1732,11 +1739,14 @@ class DatagramChannelImpl
                 long reader = readerThread;
                 long writer = writerThread;
                 if (reader != 0 || writer != 0) {
-                    nd.preClose(fd);
+                    if (!AIX.isAIX)
+                        nd.preClose(fd);
                     if (reader != 0)
                         NativeThread.signal(reader);
                     if (writer != 0)
                         NativeThread.signal(writer);
+                    if (AIX.isAIX)
+                        nd.preClose(fd);
                 }
             }
         }

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.nio.ch;
 
 import java.io.FileDescriptor;
@@ -56,6 +62,7 @@ import sun.net.NetHooks;
 import sun.net.PlatformSocketImpl;
 import sun.net.ResourceManager;
 import sun.net.ext.ExtendedSocketOptions;
+import sun.net.util.AIX;
 import sun.net.util.SocketExceptions;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -909,13 +916,16 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
             // then the socket is pre-closed and the thread(s) signalled. The
             // last thread will close the file descriptor.
             if (!tryClose()) {
-                nd.preClose(fd);
+                if (!AIX.isAIX)
+                    nd.preClose(fd);
                 long reader = readerThread;
                 if (reader != 0)
                     NativeThread.signal(reader);
                 long writer = writerThread;
                 if (writer != 0)
                     NativeThread.signal(writer);
+                if (AIX.isAIX)
+                    nd.preClose(fd);
             }
         }
     }

--- a/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.nio.ch;
 
 import java.io.FileDescriptor;
@@ -57,6 +63,7 @@ import static java.net.StandardProtocolFamily.UNIX;
 
 import sun.net.NetHooks;
 import sun.net.ext.ExtendedSocketOptions;
+import sun.net.util.AIX;
 
 /**
  * An implementation of ServerSocketChannels
@@ -583,8 +590,11 @@ class ServerSocketChannelImpl
             if (!tryClose()) {
                 long th = thread;
                 if (th != 0) {
-                    nd.preClose(fd);
+                    if (!AIX.isAIX)
+                        nd.preClose(fd);
                     NativeThread.signal(th);
+                    if (AIX.isAIX)
+                        nd.preClose(fd);
                 }
             }
         }

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.nio.ch;
 
 import java.io.FileDescriptor;
@@ -62,6 +68,7 @@ import static java.net.StandardProtocolFamily.UNIX;
 import sun.net.ConnectionResetException;
 import sun.net.NetHooks;
 import sun.net.ext.ExtendedSocketOptions;
+import sun.net.util.AIX;
 import sun.net.util.SocketExceptions;
 
 /**
@@ -1014,11 +1021,14 @@ class SocketChannelImpl
                 long reader = readerThread;
                 long writer = writerThread;
                 if (reader != 0 || writer != 0) {
-                    nd.preClose(fd);
+                    if (!AIX.isAIX)
+                        nd.preClose(fd);
                     if (reader != 0)
                         NativeThread.signal(reader);
                     if (writer != 0)
                         NativeThread.signal(writer);
+                    if (AIX.isAIX)
+                        nd.preClose(fd);
                 }
             }
         }

--- a/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.nio.ch;
 
 import java.io.FileDescriptor;
@@ -36,6 +42,8 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.spi.SelectorProvider;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
+
+import sun.net.util.AIX;
 
 class SinkChannelImpl
     extends Pipe.SinkChannel
@@ -123,8 +131,11 @@ class SinkChannelImpl
             if (!tryClose()) {
                 long th = thread;
                 if (th != 0) {
-                    nd.preClose(fd);
+                    if (!AIX.isAIX)
+                        nd.preClose(fd);
                     NativeThread.signal(th);
+                    if (AIX.isAIX)
+                        nd.preClose(fd);
                 }
             }
         }

--- a/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.nio.ch;
 
 import java.io.FileDescriptor;
@@ -36,6 +42,8 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.spi.SelectorProvider;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
+
+import sun.net.util.AIX;
 
 class SourceChannelImpl
     extends Pipe.SourceChannel
@@ -123,8 +131,11 @@ class SourceChannelImpl
             if (!tryClose()) {
                 long th = thread;
                 if (th != 0) {
-                    nd.preClose(fd);
+                    if (!AIX.isAIX)
+                        nd.preClose(fd);
                     NativeThread.signal(th);
+                    if (AIX.isAIX)
+                        nd.preClose(fd);
                 }
             }
         }


### PR DESCRIPTION
During fcntl, dup2 system calls if read/write happens then PreClose method gets hang. This issue is not seen if we Signal/Kill the thread first and then call the preClose method.