### PR TITLE
Removed JFR Start, Dump Unsupported options help for JDK17

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
@@ -201,31 +201,6 @@ final class DCmdDump extends AbstractDCmd {
 
                Options:
 
-                 begin           (Optional) Specify the time from which recording data will be included
-                                 in the dump file. The format is specified as local time.
-                                 (STRING, no default value)
-
-                 end             (Optional) Specify the time to which recording data will be included
-                                 in the dump file. The format is specified as local time.
-                                 (STRING, no default value)
-
-                                 Note: For both begin and end, the time must be in a format that can
-                                 be read by any of these methods:
-
-                                  java.time.LocalTime::parse(String),
-                                  java.time.LocalDateTime::parse(String)
-                                  java.time.Instant::parse(String)
-
-                                 For example, "13:20:15", "2020-03-17T09:00:00" or
-                                 "2020-03-17T09:00:00Z".
-
-                                 Note: begin and end times correspond to the timestamps found within
-                                 the recorded information in the flight recording data.
-
-                                 Another option is to use a time relative to the current time that is
-                                 specified by a negative integer followed by "s", "m" or "h".
-                                 For example, "-12h", "-15m" or "-30s"
-
                  filename        (Optional) Name of the file to which the flight recording data is
                                  dumped. If no filename is given, a filename is generated from the PID
                                  and the current date. The filename may also be a directory in which
@@ -244,13 +219,6 @@ final class DCmdDump extends AbstractDCmd {
                  name            (Optional) Name of the recording. If no name is given, data from all
                                  recordings is dumped. (STRING, no default value)
 
-                 path-to-gc-root (Optional) Flag for saving the path to garbage collection (GC) roots
-                                 at the time the recording data is dumped. The path information is
-                                 useful for finding memory leaks but collecting it can cause the
-                                 application to pause for a short period of time. Turn on this flag
-                                 only when you have an application that you suspect has a memory
-                                 leak. (BOOLEAN, false)
-
                Options must be specified using the <key> or <key>=<value> syntax.
 
                Example usage:
@@ -261,13 +229,6 @@ final class DCmdDump extends AbstractDCmd {
                 $ jcmd <pid> JFR.dump name=1 filename=%s
                 $ jcmd <pid> JFR.dump maxage=1h
                 $ jcmd <pid> JFR.dump maxage=1h maxsize=50M
-                $ jcmd <pid> JFR.dump fillename=leaks.jfr path-to-gc-root=true
-                $ jcmd <pid> JFR.dump begin=13:15
-                $ jcmd <pid> JFR.dump begin=13:15 end=21:30:00
-                $ jcmd <pid> JFR.dump end=18:00 maxage=10m
-                $ jcmd <pid> JFR.dump begin=2021-09-15T09:00:00 end=2021-09-15T10:00:00
-                $ jcmd <pid> JFR.dump begin=-1h
-                $ jcmd <pid> JFR.dump begin=-15m end=-5m
 
                """.formatted(exampleDirectory(), exampleFilename()).lines().toArray(String[]::new);
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -319,14 +319,6 @@ final class DCmdStart extends AbstractDCmd {
                  disk            (Optional) Flag for also writing the data to disk while recording
                                  (BOOLEAN, true)
 
-                 dumponexit      (Optional) Flag for writing the recording to disk when the Java
-                                 Virtual Machine (JVM) shuts down. If set to 'true' and no value
-                                 is given for filename, the recording is written to a file in the
-                                 directory where the process was started. The file name is a
-                                 system-generated name that contains the process ID, the recording
-                                 ID and the current time stamp. (For example:
-                                 id-1-2021_09_14_09_00.jfr) (BOOLEAN, false)
-
                  duration        (Optional) Length of time to record. Note that 0s means forever
                                  (INTEGER followed by 's' for seconds 'm' for minutes or 'h' for
                                  hours, 0s)
@@ -351,20 +343,6 @@ final class DCmdStart extends AbstractDCmd {
                                  be less than the value for the maxchunksize parameter set with
                                  the JFR.configure command. (STRING, 0 (no max size))
 
-                 name            (Optional) Name of the recording. If no name is provided, a name
-                                 is generated. Make note of the generated name that is shown in
-                                 the response to the command so that you can use it with other
-                                 commands. (STRING, system-generated default name)
-
-                 path-to-gc-root (Optional) Flag for saving the path to garbage collection (GC)
-                                 roots at the end of a recording. The path information is useful
-                                 for finding memory leaks but collecting it is time consuming.
-                                 Turn on this flag only when you have an application that you
-                                 suspect has a memory leak. If the settings parameter is set to
-                                 'profile', then the information collected includes the stack
-                                 trace from where the potential leaking object wasallocated.
-                                 (BOOLEAN, false)
-
                  settings        (Optional) Name of the settings file that identifies which events
                                  to record. To specify more than one file, use the settings
                                  parameter repeatedly. Include the path if the file is not in
@@ -379,20 +357,6 @@ final class DCmdStart extends AbstractDCmd {
                                  without a predefined configuration file. (STRING,
                                  JAVA-HOME/lib/jfr/default.jfc)
 
-               Event settings and .jfc options can also be specified using the following syntax:
-
-                 jfc-option=value    (Optional) The option value to modify. To see available
-                                     options for a .jfc file, use the 'jfr configure' command.
-
-                 event-setting=value (Optional) The event setting value to modify. Use the form:
-                                     <event-name>#<setting-name>=<value>
-                                     To add a new event setting, prefix the event name with '+'.
-
-               In case of a conflict between a parameter and a .jfc option, the parameter will
-               take  precedence. The whitespace character can be omitted for timespan values,
-               i.e. 20s. For more information about the settings syntax, see Javadoc of the
-               jdk.jfr package.
-
                Options must be specified using the <key> or <key>=<value> syntax.
 
                Example usage:
@@ -404,11 +368,6 @@ final class DCmdStart extends AbstractDCmd {
                 $ jcmd <pid> JFR.start maxage=1h,maxsize=1000M
                 $ jcmd <pid> JFR.start settings=profile
                 $ jcmd <pid> JFR.start delay=5m,settings=my.jfc
-                $ jcmd <pid> JFR.start gc=high method-profiling=high
-                $ jcmd <pid> JFR.start jdk.JavaMonitorEnter#threshold=1ms
-                $ jcmd <pid> JFR.start +HelloWorld#enabled=true +HelloWorld#stackTrace=true
-                $ jcmd <pid> JFR.start settings=user.jfc com.example.UserDefined#enabled=true
-                $ jcmd <pid> JFR.start settings=none +Hello#enabled=true
 
                Note, if the default event settings are modified, overhead may exceed 1%%.
 


### PR DESCRIPTION
Delete Unsupported JFR help options for JFR.Start and JFR.Dump 