### PR TITLE
Allow RestrictedSecurity property extension from default values

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -1332,6 +1332,48 @@ public final class RestrictedSecurity {
             }
         }
 
+        private String getExistingValue(String property) {
+            if (debug != null) {
+                debug.println("\tGetting previous value of property: " + property);
+            }
+
+            // Look for values from profiles that this one extends.
+            String existingValue = profileProperties.get(property);
+            String debugMessage = "\t\tPrevious value from extended profile: ";
+
+            // If there is no value, look for non-profile values in java.security file.
+            if (existingValue == null) {
+                debugMessage = "\t\tPrevious value from java.security file: ";
+                String propertyKey;
+                switch (property) {
+                case "jdkCertpathDisabledAlgorithms":
+                    propertyKey = "jdk.certpath.disabledAlgorithms";
+                    break;
+                case "jdkSecurityLegacyAlgorithms":
+                    propertyKey = "jdk.security.legacyAlgorithms";
+                    break;
+                case "jdkTlsDisabledAlgorithms":
+                    propertyKey = "jdk.tls.disabledAlgorithms";
+                    break;
+                case "jdkTlsDisabledNamedCurves":
+                    propertyKey = "jdk.tls.disabledNamedCurves";
+                    break;
+                case "jdkTlsLegacyAlgorithms":
+                    propertyKey = "jdk.tls.legacyAlgorithms";
+                    break;
+                default:
+                    return null;
+                }
+                existingValue = securityProps.getProperty(propertyKey);
+            }
+
+            if ((debug != null) && (existingValue != null)) {
+                debug.println(debugMessage + existingValue);
+            }
+
+            return existingValue;
+        }
+
         /**
          * Load restricted security properties.
          */
@@ -1603,7 +1645,7 @@ public final class RestrictedSecurity {
                 allInfo.add(propertyKey + "=" + value);
 
                 // Check if property overrides, adds to or removes from previous value.
-                String existingValue = profileProperties.get(property);
+                String existingValue = getExistingValue(property);
                 if (value.startsWith("+")) {
                     if (!isPropertyAppendable(property)) {
                         printStackTraceAndExit("Property '" + property + "' is not appendable.");
@@ -1613,7 +1655,8 @@ public final class RestrictedSecurity {
 
                         // Take existing value of property into account, if applicable.
                         if (existingValue == null) {
-                            printStackTraceAndExit("Property '" + property + "' does not exist in parent profile. Cannot append.");
+                            printStackTraceAndExit("Property '" + property + "' does not exist in"
+                                    + " parent profile or java.security file. Cannot append.");
                         } else if (existingValue.isBlank()) {
                             newValue = value;
                         } else {
@@ -1627,6 +1670,10 @@ public final class RestrictedSecurity {
                         // Remove values from property.
                         value = value.substring(1).trim();
                         if (!value.isBlank()) {
+                            if (existingValue == null) {
+                                printStackTraceAndExit("Property '" + property + "' does not exist in"
+                                    + " parent profile or java.security file. Cannot remove.");
+                            }
                             List<String> existingValues = Stream.of(existingValue.split(","))
                                                                 .map(v -> v.trim())
                                                                 .collect(Collectors.toList());
@@ -1640,7 +1687,8 @@ public final class RestrictedSecurity {
                         } else {
                             // Nothing to do. Use existing value of property into account, if available.
                             if (existingValue == null) {
-                                printStackTraceAndExit("Property '" + property + "' does not exist in parent profile. Cannot remove.");
+                                printStackTraceAndExit("Property '" + property + "' does not exist in"
+                                    + " parent profile or java.security file. Cannot remove.");
                             } else if (existingValue.isBlank()) {
                                 newValue = value;
                             } else {

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -182,25 +182,14 @@ RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.default = false
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:4a85dc0db2f257388155b3ada7378773884edc89c80c8d715f4bdde84cc3d8bd
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:bea1b7da967ac27720b7bc439ccd2d4250ebe783a6919a8e7047e6a6b862a116
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.number = Certificate #XXX
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.sunsetDate = 2026-09-21
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.fips.mode = 140-3
 
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.disabledNamedCurves =
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.disabledAlgorithms = \
-    3DES_EDE_CBC, \
-    anon, \
-    DES, \
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.disabledAlgorithms = + \
     DH keySize < 2048, \
-    DTLSv1.0, \
-    EC keySize < 224, \
-    ECDH, \
-    MD5withRSA, \
-    NULL, \
-    RC4, \
-    SSLv3, \
     TLS_DHE_DSS_WITH_AES_128_CBC_SHA, \
     TLS_DHE_DSS_WITH_AES_128_CBC_SHA256, \
     TLS_DHE_DSS_WITH_AES_128_GCM_SHA256, \
@@ -224,15 +213,9 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.disabledAlgorithms = \
     TLS_RSA_WITH_AES_256_CBC_SHA, \
     TLS_RSA_WITH_AES_256_CBC_SHA256, \
     TLS_RSA_WITH_AES_256_GCM_SHA384, \
-    TLSv1, \
-    TLSv1.1, \
     X25519, \
     X448
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.ephemeralDHKeySize =
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.legacyAlgorithms =
 
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.certpath.disabledAlgorithms =
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.legacyAlgorithms =
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS [ \
     {AlgorithmParameterGenerator, AESGCM, *}, \
     {AlgorithmParameterGenerator, CCM, *}, \


### PR DESCRIPTION
The default values existing in the java.security file are now considered the baseline and all profiles can inherit them and add or remove to them, if they are in list form. This does not include the providers, though.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/849

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>