### PR TITLE
Add more granular digest flags

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -89,10 +89,49 @@ import static sun.security.util.SecurityProviderConstants.getAliases;
 
 public final class SunEntries {
 
-    /* The property 'jdk.nativeDigest' is used to control enablement of the native
-     * digest implementation.
-     */
-    private static final boolean useNativeDigest = NativeCrypto.isAlgorithmEnabled("jdk.nativeDigest", "MessageDigest");
+    private static final boolean useNativeMD5;
+    private static final boolean useNativeSHA;
+    private static final boolean useNativeSHA224;
+    private static final boolean useNativeSHA256;
+    private static final boolean useNativeSHA384;
+    private static final boolean useNativeSHA512;
+
+    static {
+        /* The property 'jdk.nativeDigest' is used to control enablement of all native
+         * digest implementations.
+         */
+        boolean useNativeDigest = NativeCrypto.isAlgorithmEnabled("jdk.nativeDigest", "MessageDigest");
+
+        /* The property 'jdk.nativeMD5' is used to control enablement of the native
+         * MD5 implementation.
+         */
+        useNativeMD5 = useNativeDigest && NativeCrypto.isAlgorithmEnabled("jdk.nativeMD5", "MD5");
+
+        /* The property 'jdk.nativeSHA' is used to control enablement of the native
+         * SHA implementation.
+         */
+        useNativeSHA = useNativeDigest && NativeCrypto.isAlgorithmEnabled("jdk.nativeSHA", "SHA");
+
+        /* The property 'jdk.nativeSHA224' is used to control enablement of the native
+         * SHA-224 implementation.
+         */
+        useNativeSHA224 = useNativeDigest && NativeCrypto.isAlgorithmEnabled("jdk.nativeSHA224", "SHA-224");
+
+        /* The property 'jdk.nativeSHA256' is used to control enablement of the native
+         * SHA-256 implementation.
+         */
+        useNativeSHA256 = useNativeDigest && NativeCrypto.isAlgorithmEnabled("jdk.nativeSHA256", "SHA-256");
+
+        /* The property 'jdk.nativeSHA384' is used to control enablement of the native
+         * SHA-384 implementation.
+         */
+        useNativeSHA384 = useNativeDigest && NativeCrypto.isAlgorithmEnabled("jdk.nativeSHA384", "SHA-384");
+
+        /* The property 'jdk.nativeSHA512' is used to control enablement of the native
+         * SHA-512 implementation.
+         */
+        useNativeSHA512 = useNativeDigest && NativeCrypto.isAlgorithmEnabled("jdk.nativeSHA512", "SHA-512");
+    }
 
     // Flag indicating whether the operating system is AIX.
     private static final boolean isAIX = "AIX".equals(GetPropertyAction.privilegedGetProperty("os.name"));
@@ -277,7 +316,7 @@ public final class SunEntries {
          * enabled or not.
          */
         /* Don't use native MD5 on AIX due to an observed performance regression. */
-        if (useNativeDigest
+        if (useNativeMD5
             && NativeCrypto.isAllowedAndLoaded()
             && NativeCrypto.isMD5Available()
             && !isAIX
@@ -287,19 +326,36 @@ public final class SunEntries {
             providerMD5 = "sun.security.provider.MD5";
         }
 
-        if (useNativeDigest && NativeCrypto.isAllowedAndLoaded()) {
+        if (useNativeSHA && NativeCrypto.isAllowedAndLoaded()) {
             providerSHA = "sun.security.provider.NativeSHA";
-            providerSHA224 = "sun.security.provider.NativeSHA2$SHA224";
-            providerSHA256 = "sun.security.provider.NativeSHA2$SHA256";
-            providerSHA384 = "sun.security.provider.NativeSHA5$SHA384";
-            providerSHA512 = "sun.security.provider.NativeSHA5$SHA512";
         } else {
             providerSHA = "sun.security.provider.SHA";
+        }
+
+        if (useNativeSHA224 && NativeCrypto.isAllowedAndLoaded()) {
+            providerSHA224 = "sun.security.provider.NativeSHA2$SHA224";
+        } else {
             providerSHA224 = "sun.security.provider.SHA2$SHA224";
+        }
+
+        if (useNativeSHA256 && NativeCrypto.isAllowedAndLoaded()) {
+            providerSHA256 = "sun.security.provider.NativeSHA2$SHA256";
+        } else {
             providerSHA256 = "sun.security.provider.SHA2$SHA256";
+        }
+
+        if (useNativeSHA384 && NativeCrypto.isAllowedAndLoaded()) {
+            providerSHA384 = "sun.security.provider.NativeSHA5$SHA384";
+        } else {
             providerSHA384 = "sun.security.provider.SHA5$SHA384";
+        }
+
+        if (useNativeSHA512 && NativeCrypto.isAllowedAndLoaded()) {
+            providerSHA512 = "sun.security.provider.NativeSHA5$SHA512";
+        } else {
             providerSHA512 = "sun.security.provider.SHA5$SHA512";
         }
+
         add(p, "MessageDigest", "MD2", "sun.security.provider.MD2", attrs);
         add(p, "MessageDigest", "MD5", providerMD5, attrs);
         addWithAlias(p, "MessageDigest", "SHA-1", providerSHA,


### PR DESCRIPTION
Instead of just having a single flag to enable/disable native support for all digest algorithms, separate flags are created for each one of them.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/862

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>