### PR TITLE
Fix profiles with same name beginnings being treated as one

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -345,9 +345,10 @@ public final class RestrictedSecurity {
             }
             String defaultMatch = null;
             boolean profileExists = false;
+            String profilePrefix = potentialProfileID + '.';
             for (Object keyObject : props.keySet()) {
                 if (keyObject instanceof String key) {
-                    if (key.startsWith(potentialProfileID)) {
+                    if (key.startsWith(profilePrefix)) {
                         profileExists = true;
                         if (key.endsWith(".desc.default")) {
                             // Check if property is set to true.

--- a/closed/test/jdk/openj9/internal/security/TestProperties.java
+++ b/closed/test/jdk/openj9/internal/security/TestProperties.java
@@ -43,6 +43,15 @@ import jdk.test.lib.process.ProcessTools;
 
 public class TestProperties {
 
+    private static Stream<Arguments> patternMatches_expectedExitValue0() {
+        return Stream.of(
+                // 1 - Test property - Same beginnings of the profile name without version.
+                Arguments.of("Test-Profile-SameStartWithoutVersion",
+                        System.getProperty("test.src") + "/property-java.security",
+                        "(?s)(?=.*Sun)(?=.*\\bSunJCE\\b)(?=.*SunJSSE)")
+        );
+    }
+
     private static Stream<Arguments> patternMatches_expectedExitValue1() {
         return Stream.of(
                 // 1 - Test profile - base profile misspell properties.
@@ -153,6 +162,19 @@ public class TestProperties {
                         System.getProperty("test.src") + "/property-java.security",
                         "You cannot add or remove to provider (.*?). This is the base profile.")
         );
+    }
+
+    @ParameterizedTest
+    @MethodSource("patternMatches_expectedExitValue0")
+    public void shouldContain_expectedExitValue0(String customprofile, String securityPropertyFile, String expected) throws Exception {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+                "-Dsemeru.fips=true",
+                "-Dsemeru.customprofile=" + customprofile,
+                "-Djava.security.properties=" + securityPropertyFile,
+                "TestProperties"
+        );
+        outputAnalyzer.reportDiagnosticSummary();
+        outputAnalyzer.shouldHaveExitValue(0).shouldMatch(expected);
     }
 
     @ParameterizedTest

--- a/closed/test/jdk/openj9/internal/security/property-java.security
+++ b/closed/test/jdk/openj9/internal/security/property-java.security
@@ -525,3 +525,39 @@ RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.jce.provider.1 =  com.s
 
 RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.securerandom.provider = OpenJCEPlusFIPS
 RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-SameStartWithoutVersion
+# Test property - Same beginnings of the profile name without version
+#
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.name = Test-Profile-SameStartWithoutVersion
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.default = true
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.fips = true
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.hash = SHA256:2c893d75043da09c3dba8d8b24cb71dc1c7ceac5fb8bf362a35847418a933a06
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.jce.provider.3 = sun.security.ssl.SunJSSE
+
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.securerandom.algorithm = SHA512DRBG
+
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.name = Test-Profile-SameStartWithoutVersionPart
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.default = true
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.fips = true
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.hash = SHA256:2c893d75043da09c3dba8d8b24cb71dc1c7ceac5fb8bf362a35847418a933a06
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.number = Certificate #XXX
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.fips.mode = 140-3
+
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.jce.provider.1 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.jce.provider.2 = com.sun.crypto.provider.SunJCE
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.jce.provider.3 = sun.security.ssl.SunJSSE
+
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.securerandom.algorithm = SHA512DRBG


### PR DESCRIPTION
Fix the issue where profiles with the same beginnings of profile name are treated as a single profile.

This is a back-port PR from JDKNext PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/887