### PR TITLE
CRIU adds @NotCheckpointSafe for MethodAccessorGenerator.generateName()

### DIFF
--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -51,6 +51,7 @@ $(eval $(call SetupCopyFiles,COPY_OVERLAY_FILES, \
 		src/java.base/share/classes/java/util/zip/ZipFile.java \
 		src/java.base/share/classes/jdk/internal/access/JavaNetInetAddressAccess.java \
 		src/java.base/share/classes/jdk/internal/ref/PhantomCleanable.java \
+		src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java \
 		src/java.base/share/classes/module-info.java \
 		src/java.base/share/classes/sun/security/jca/ProviderConfig.java \
 		src/java.base/share/classes/sun/security/jca/ProviderList.java \

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java
@@ -23,10 +23,20 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package jdk.internal.reflect;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT */
 
 /** Generator for sun.reflect.MethodAccessor and
     sun.reflect.ConstructorAccessor objects using bytecodes to
@@ -748,6 +758,9 @@ class MethodAccessorGenerator extends AccessorGenerator {
         return sb.toString();
     }
 
+    /*[IF CRIU_SUPPORT]*/
+    @NotCheckpointSafe
+    /*[ENDIF] CRIU_SUPPORT */
     private static synchronized String generateName(boolean isConstructor,
                                                     boolean forSerialization)
     {


### PR DESCRIPTION
CRIU adds `@NotCheckpointSafe` for `MethodAccessorGenerator.generateName()`

Porting
* https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/236

`jdk/internal/reflect/MethodAccessorGenerator` only presents in JDK 21/17/11/8.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>