### PR TITLE
Add selected tracepoints for OpenJ9 -Xtrace

### DIFF
--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
 # ===========================================================================
 
 include LibCommon.gmk
@@ -74,6 +74,26 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBNIO, \
     OPTIMIZATION := HIGH, \
     WARNINGS_AS_ERRORS_xlc := false, \
     CFLAGS := $(CFLAGS_JDKLIB), \
+    FileDispatcherImpl.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    Net.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    nio_util.c_CFLAGS := \
+        -I$(OPENJ9_TOPDIR)/runtime/include \
+        -I$(OPENJ9_TOPDIR)/runtime/oti \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR) \
+        -I$(OPENJ9_TOPDIR)/runtime/jcl \
+        -I$(OPENJ9_TOPDIR)/runtime/util \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    SocketDispatcher.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    UnixDomainSockets.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
     DISABLED_WARNINGS_gcc := undef, \
     DISABLED_WARNINGS_clang := undef, \
     EXTRA_HEADER_DIRS := \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+
 ##########################################################################################
 # libfdlibm is statically linked with libjava below and not delivered into the
 # product on its own.
@@ -91,8 +95,30 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
     OPTIMIZATION := HIGH, \
     CFLAGS := $(CFLAGS_JDKLIB) \
         $(LIBJAVA_CFLAGS), \
+    check_version.c_CFLAGS := \
+        -I$(OPENJ9_TOPDIR)/runtime/include \
+        -I$(OPENJ9_TOPDIR)/runtime/oti \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR) \
+        -I$(OPENJ9_TOPDIR)/runtime/jcl \
+        -I$(OPENJ9_TOPDIR)/runtime/util \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    io_util_md.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
     jdk_util.c_CFLAGS := $(VERSION_CFLAGS), \
     ProcessImpl_md.c_CFLAGS := $(VERSION_CFLAGS), \
+    UnixFileSystem_md.c_CFLAGS := \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
+    VM.c_CFLAGS := \
+        -I$(OPENJ9_TOPDIR)/runtime/include \
+        -I$(OPENJ9_TOPDIR)/runtime/oti \
+        -I$(OPENJ9OMR_TOPDIR)/include_core \
+        -I$(OPENJ9_VM_BUILD_DIR) \
+        -I$(OPENJ9_TOPDIR)/runtime/jcl \
+        -I$(OPENJ9_TOPDIR)/runtime/util \
+        -I$(OPENJ9_VM_BUILD_DIR)/jcl, \
     EXTRA_HEADER_DIRS := libfdlibm, \
     WARNINGS_AS_ERRORS_xlc := false, \
     DISABLED_WARNINGS_gcc := unused-result unused-function, \

--- a/src/java.base/share/native/libjava/VM.c
+++ b/src/java.base/share/native/libjava/VM.c
@@ -23,12 +23,25 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
 #include "jdk_util.h"
 
 #include "jdk_internal_misc_VM.h"
+
+#if defined(AIX) || defined(WIN32)
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_java.c"
+#endif /* defined(AIX) || defined(WIN32) */
 
 /* Only register the performance-critical methods */
 static JNINativeMethod methods[] = {
@@ -42,6 +55,11 @@ Java_jdk_internal_misc_VM_latestUserDefinedLoader0(JNIEnv *env, jclass cls) {
 
 JNIEXPORT void JNICALL
 Java_jdk_internal_misc_VM_initialize(JNIEnv *env, jclass cls) {
+#if defined(AIX) || defined(WIN32)
+    /* Other platforms do this in check_version.c JNI_OnLoad. */
+    UT_JCL_JAVA_MODULE_LOADED(J9_UTINTERFACE_FROM_VM(((J9VMThread *) env)->javaVM));
+#endif /* defined(AIX) || defined(WIN32) */
+
     // Registers implementations of native methods described in methods[]
     // above.
     // In particular, registers JVM_GetNanoTimeAdjustment as the implementation

--- a/src/java.base/share/native/libjava/check_version.c
+++ b/src/java.base/share/native/libjava/check_version.c
@@ -23,12 +23,30 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
 
+#if !defined(AIX) && !defined(WIN32)
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_java.c"
+#endif /* !defined(AIX) && !defined(WIN32) */
+
 JNIEXPORT jint JNICALL
 DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
 {
+#if !defined(AIX) && !defined(WIN32)
+    /* Windows and AIX don't call JNI_OnLoad for libjava.dll, initialize the tracepoint elsewhere. */
+    UT_JCL_JAVA_MODULE_LOADED(J9_UTINTERFACE_FROM_VM((J9JavaVM *)vm));
+#endif /* !defined(AIX) && !defined(WIN32) */
+
     return JNI_VERSION_1_2;
 }

--- a/src/java.base/share/native/libnio/nio_util.c
+++ b/src/java.base/share/native/libnio/nio_util.c
@@ -23,9 +23,20 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jvm.h"
 #include "jni_util.h"
+
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_nio.c"
 
 JNIEXPORT jint JNICALL
 DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
@@ -35,6 +46,8 @@ DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_2) != JNI_OK) {
         return JNI_EVERSION; /* JNI version not supported */
     }
+
+    UT_JCL_NIO_MODULE_LOADED(J9_UTINTERFACE_FROM_VM((J9JavaVM *)vm));
 
     return JNI_VERSION_1_2;
 }

--- a/src/java.base/unix/native/libjava/UnixFileSystem_md.c
+++ b/src/java.base/unix/native/libjava/UnixFileSystem_md.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <unistd.h>
 #include <assert.h>
 #include <sys/types.h>
@@ -50,6 +56,8 @@
 #include "io_util_md.h"
 #include "java_io_FileSystem.h"
 #include "java_io_UnixFileSystem.h"
+
+#include "ut_jcl_java.h"
 
 #if defined(_AIX)
   #if !defined(NAME_MAX)
@@ -281,6 +289,7 @@ Java_java_io_UnixFileSystem_createFileExclusively(JNIEnv *env, jclass cls,
                 if (errno != EEXIST)
                     JNU_ThrowIOExceptionWithLastError(env, "Could not open file");
             } else {
+                Trc_io_UnixFileSystem_createFileExclusively_close(fd);
                 if (close(fd) == -1)
                     JNU_ThrowIOExceptionWithLastError(env, "Could not close file");
                 rv = JNI_TRUE;

--- a/src/java.base/unix/native/libjava/io_util_md.c
+++ b/src/java.base/unix/native/libjava/io_util_md.c
@@ -22,6 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
@@ -38,6 +45,8 @@
 #include <linux/fs.h>
 #include <sys/stat.h>
 #endif
+
+#include "ut_jcl_java.h"
 
 #ifdef MACOSX
 
@@ -89,6 +98,11 @@ handleOpen(const char *path, int oflag, int mode) {
             close(fd);
             fd = -1;
         }
+    }
+    if (-1 == fd) {
+        Trc_io_handleOpen_err(path, oflag, mode, 0, 0, errno);
+    } else {
+        Trc_io_handleOpen(path, oflag, mode, 0, 0, (jlong)fd);
     }
     return fd;
 }
@@ -167,6 +181,7 @@ fileDescriptorClose(JNIEnv *env, jobject this)
             dup2(devnull, fd);
             close(devnull);
         }
+        Trc_io_fileDescriptorClose((jlong)fd);
     } else {
         int result;
 #if defined(_AIX)
@@ -176,7 +191,10 @@ fileDescriptorClose(JNIEnv *env, jobject this)
         result = close(fd);
 #endif
         if (result == -1 && errno != EINTR) {
+            Trc_io_fileDescriptorClose_err((jlong)fd, errno);
             JNU_ThrowIOExceptionWithLastError(env, "close failed");
+        } else {
+            Trc_io_fileDescriptorClose((jlong)fd);
         }
     }
 }

--- a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <fcntl.h>
@@ -62,6 +68,8 @@
 #include "nio_util.h"
 #include "sun_nio_ch_FileDispatcherImpl.h"
 #include "java_lang_Long.h"
+
+#include "ut_jcl_nio.h"
 
 static int preCloseFD = -1;     /* File descriptor to which we dup other fd's
                                    before closing them for real */
@@ -301,6 +309,7 @@ Java_sun_nio_ch_FileDispatcherImpl_release0(JNIEnv *env, jobject this,
 
 static void closeFileDescriptor(JNIEnv *env, int fd) {
     if (fd != -1) {
+        Trc_nio_ch_FileDispatcherImpl_close(fd);
         int result = close(fd);
         if (result < 0)
             JNU_ThrowIOExceptionWithLastError(env, "Close failed");

--- a/src/java.base/unix/native/libnio/ch/Net.c
+++ b/src/java.base/unix/native/libnio/ch/Net.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <poll.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -30,6 +36,7 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <limits.h>
+#include <arpa/inet.h>
 
 #include "jni.h"
 #include "jni_util.h"
@@ -45,6 +52,8 @@
 #include <stdlib.h>
 #include <sys/utsname.h>
 #endif
+
+#include "ut_jcl_nio.h"
 
 /**
  * IP_MULTICAST_ALL supported since 2.6.31 but may not be available at
@@ -364,12 +373,22 @@ Java_sun_nio_ch_Net_connect0(JNIEnv *env, jclass clazz, jboolean preferIPv6,
     SOCKETADDRESS sa;
     int sa_len = 0;
     int rv;
+    int fd;
 
     if (NET_InetAddressToSockaddr(env, iao, port, &sa, &sa_len, preferIPv6) != 0) {
         return IOS_THROWN;
     }
 
-    rv = connect(fdval(env, fdo), &sa.sa, sa_len);
+    fd = fdval(env, fdo);
+    if (AF_INET == sa.sa4.sin_family) {
+        char buf[INET_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect4((jlong)fd, inet_ntop(AF_INET, &sa.sa4.sin_addr, buf, sizeof(buf)), port, sa_len);
+    } else if (AF_INET6 == sa.sa6.sin6_family) {
+        char buf[INET6_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect6((jlong)fd, inet_ntop(AF_INET6, &sa.sa6.sin6_addr, buf, sizeof(buf)), port, ntohl(sa.sa6.sin6_scope_id), sa_len);
+    }
+
+    rv = connect(fd, &sa.sa, sa_len);
     if (rv != 0) {
         if (errno == EINPROGRESS) {
             return IOS_UNAVAILABLE;

--- a/src/java.base/unix/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/unix/native/libnio/ch/UnixDomainSockets.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <poll.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -40,6 +46,8 @@
 #include "sun_nio_ch_Net.h"
 #include "nio_util.h"
 #include "nio.h"
+
+#include "ut_jcl_nio.h"
 
 /* Subtle platform differences in how unnamed sockets (empty path)
  * are returned from getsockname()
@@ -132,12 +140,16 @@ Java_sun_nio_ch_UnixDomainSockets_connect0(JNIEnv *env, jclass clazz, jobject fd
     struct sockaddr_un sa;
     int sa_len = 0;
     int rv;
+    int fd;
 
     if (unixSocketAddressToSockaddr(env, path, &sa, &sa_len) != 0) {
         return IOS_THROWN;
     }
 
-    rv = connect(fdval(env, fdo), (struct sockaddr *)&sa, sa_len);
+    fd = fdval(env, fdo);
+    Trc_nio_ch_UnixDomainSockets_connect(fd, sa.sun_path, sa_len);
+
+    rv = connect(fd, (struct sockaddr *)&sa, sa_len);
     if (rv != 0) {
         if (errno == EINPROGRESS) {
             return IOS_UNAVAILABLE;

--- a/src/java.base/windows/native/libjava/io_util_md.c
+++ b/src/java.base/windows/native/libjava/io_util_md.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jni_util.h"
 #include "jvm.h"
@@ -41,6 +47,7 @@
 #include <limits.h>
 #include <wincon.h>
 
+#include "ut_jcl_java.h"
 
 static DWORD MAX_INPUT_EVENTS = 2000;
 
@@ -236,12 +243,22 @@ FD winFileHandleOpen(JNIEnv *env, jstring path, int flags)
         FILE_ATTRIBUTE_NORMAL;
     const DWORD flagsAndAttributes = maybeWriteThrough | maybeDeleteOnClose;
     HANDLE h = NULL;
+    char *pathStr = NULL;
 
     WCHAR *pathbuf = pathToNTPath(env, path, JNI_TRUE);
     if (pathbuf == NULL) {
         /* Exception already pending */
         return -1;
     }
+
+    if (TrcEnabled_Trc_io_handleOpen) {
+        int length = WideCharToMultiByte(CP_UTF8, 0, pathbuf, -1, NULL, 0, NULL, NULL);
+        pathStr = malloc(length);
+        if (NULL != pathStr) {
+            WideCharToMultiByte(CP_UTF8, 0, pathbuf, -1, pathStr, length, NULL, NULL);
+        }
+    }
+
     h = CreateFileW(
         pathbuf,            /* Wide char path name */
         access,             /* Read and/or write permission */
@@ -253,9 +270,13 @@ FD winFileHandleOpen(JNIEnv *env, jstring path, int flags)
     free(pathbuf);
 
     if (h == INVALID_HANDLE_VALUE) {
+        Trc_io_handleOpen_err(pathStr, access, sharing, disposition, flagsAndAttributes, GetLastError());
+        free(pathStr);
         throwFileNotFoundException(env, path);
         return -1;
     }
+    Trc_io_handleOpen(pathStr, access, sharing, disposition, flagsAndAttributes, (jlong)h);
+    free(pathStr);
     return (jlong) h;
 }
 
@@ -559,7 +580,10 @@ fileDescriptorClose(JNIEnv *env, jobject this)
     }
 
     if (CloseHandle(h) == 0) { /* Returns zero on failure */
+        Trc_io_fileDescriptorClose_err((jlong)fd, GetLastError());
         JNU_ThrowIOExceptionWithLastError(env, "close failed");
+    } else {
+        Trc_io_fileDescriptorClose((jlong)fd);
     }
 }
 

--- a/src/java.base/windows/native/libnio/ch/Net.c
+++ b/src/java.base/windows/native/libnio/ch/Net.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 
@@ -36,6 +42,8 @@
 
 #include "sun_nio_ch_Net.h"
 #include "sun_nio_ch_PollArrayWrapper.h"
+
+#include "ut_jcl_nio.h"
 
 /**
  * Definitions to allow for building with older SDK include files.
@@ -237,6 +245,14 @@ Java_sun_nio_ch_Net_connect0(JNIEnv *env, jclass clazz, jboolean preferIPv6, job
      */
     if (so_rv == 0 && type == SOCK_STREAM && IS_LOOPBACK_ADDRESS(&sa)) {
         NET_EnableFastTcpLoopbackConnect((jint)s);
+    }
+
+    if (AF_INET == sa.sa4.sin_family) {
+        char buf[INET_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect4((jlong)s, inet_ntop(AF_INET, &sa.sa4.sin_addr, buf, sizeof(buf)), port, sa_len);
+    } else if (AF_INET6 == sa.sa6.sin6_family) {
+        char buf[INET6_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect6((jlong)s, inet_ntop(AF_INET6, &sa.sa6.sin6_addr, buf, sizeof(buf)), port, ntohl(sa.sa6.sin6_scope_id), sa_len);
     }
 
     rv = connect(s, &sa.sa, sa_len);

--- a/src/java.base/windows/native/libnio/ch/SocketDispatcher.c
+++ b/src/java.base/windows/native/libnio/ch/SocketDispatcher.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 #include <ctype.h>
@@ -33,6 +39,8 @@
 #include "sun_nio_ch_SocketDispatcher.h"
 #include "nio.h"
 #include "nio_util.h"
+
+#include "ut_jcl_nio.h"
 
 
 /**************************************************************
@@ -282,6 +290,7 @@ Java_sun_nio_ch_SocketDispatcher_writev0(JNIEnv *env, jclass clazz,
 JNIEXPORT void JNICALL
 Java_sun_nio_ch_SocketDispatcher_close0(JNIEnv *env, jclass clazz, jint fd)
 {
+    Trc_nio_ch_SocketDispatcher_close(fd);
     if (closesocket(fd) == SOCKET_ERROR) {
         JNU_ThrowIOExceptionWithLastError(env, "Socket close failed");
     }

--- a/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 
@@ -37,6 +43,8 @@
 #include "java_net_InetAddress.h"
 #include "sun_nio_ch_Net.h"
 #include "sun_nio_ch_PollArrayWrapper.h"
+
+#include "ut_jcl_nio.h"
 
 /* The winsock provider ID of the Microsoft AF_UNIX implementation */
 static GUID MS_PROVIDER_ID  = {0xA00943D9,0x9C2E,0x4633,{0x9B,0x59,0,0x57,0xA3,0x16,0x09,0x94}};
@@ -192,12 +200,16 @@ Java_sun_nio_ch_UnixDomainSockets_connect0(JNIEnv *env, jclass clazz, jobject fd
     struct sockaddr_un sa;
     int sa_len = 0;
     int rv;
+    int fd;
 
     if (unixSocketAddressToSockaddr(env, addr, &sa, &sa_len) != 0) {
         return IOS_THROWN;
     }
 
-    rv = connect(fdval(env, fdo), (const struct sockaddr *)&sa, sa_len);
+    fd = fdval(env, fdo);
+    Trc_nio_ch_UnixDomainSockets_connect(fd, sa.sun_path, sa_len);
+
+    rv = connect(fd, (const struct sockaddr *)&sa, sa_len);
     if (rv != 0) {
         int err = WSAGetLastError();
         if (err == WSAEINPROGRESS || err == WSAEWOULDBLOCK) {


### PR DESCRIPTION
Depends on https://github.com/eclipse-openj9/openj9/pull/20936

Issue https://github.ibm.com/runtimes/semeru-requests/issues/46

Backport https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/243
I used a cherry pick, fixing conflicts in the .gmk files and adding the nio close tracepoint to `unix/native/libnio/ch/FileDispatcherImpl.c` since `UnixDispatcher.c` doesn't exist in jdk17.
Fixed AIX to initialize the tracepoints in libjava.

Linux jcl_java(io) tracepoints
```
16:22:40.608 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xc2, sharing=0x1b6, creation=0x0, attributes=0x0, handle=12)
16:22:40.608 0x25a00        jcl_java.4         - io_createFileExclusively_close(handle=12)
16:22:40.608 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x241, sharing=0x1b6, creation=0x0, attributes=0x0, handle=12)
16:22:40.608 0x25a00        jcl_java.0         - io_fileDescriptorClose(handle=12)
```

Linux jcl_nio tracepoints
```
16:22:51.666*0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=12, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=43657 scope_id=0), length=28)
16:22:51.666 0x25a00         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=12)
16:22:51.672 0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=12, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=43657 scope_id=0), length=28)
16:22:51.672 0x25a00         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=12)

16:26:32.701*0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=12, connect_to(AF_INET: addr=127.0.0.1 port=41937), length=16)
16:26:32.702 0x25a00         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=12)
16:26:32.708 0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=12, connect_to(AF_INET: addr=127.0.0.1 port=41937), length=16)
16:26:32.708 0x25a00         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=12)
```

amac jcl_java(io) tracepoints
```
17:59:09.745 0x152088900        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xa02, sharing=0x1b6, creation=0x0, attributes=0x0, handle=9)
17:59:09.745 0x152088900        jcl_java.4         - io_createFileExclusively_close(handle=9)
17:59:09.745 0x152088900        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x601, sharing=0x1b6, creation=0x0, attributes=0x0, handle=9)
17:59:09.745 0x152088900        jcl_java.0         - io_fileDescriptorClose(handle=9)
```

amac jcl_nio tracepoints
```
17:59:52.362*0x15480c500         jcl_nio.1         - nio_ch_Net_Connect(descriptor=9, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=64028 scope_id=0), length=28)
17:59:52.366 0x15480c500         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=9)
17:59:52.374 0x15480c500         jcl_nio.1         - nio_ch_Net_Connect(descriptor=9, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=64028 scope_id=0), length=28)
17:59:52.374 0x15480c500         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=9)

18:00:45.319*0x12488e500         jcl_nio.0         - nio_ch_Net_Connect(descriptor=9, connect_to(AF_INET: addr=127.0.0.1 port=64031), length=16)
18:00:45.323 0x12488e500         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=9)
18:00:45.331 0x12488e500         jcl_nio.0         - nio_ch_Net_Connect(descriptor=9, connect_to(AF_INET: addr=127.0.0.1 port=64031), length=16)
18:00:45.331 0x12488e500         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=9)
```

Windows jcl_java(io) tracepoints
```
21:04:04.923 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x40000000, sharing=0x3, creation=0x2, attributes=0x80, handle=1992)
21:04:04.926 0x25a00        jcl_java.0         - io_fileDescriptorClose(handle=1992)
```

Windows jcl_nio tracepoints
```
21:04:50.534*0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=2004, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=56704 scope_id=0), length=28)
21:04:50.536 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2004)
21:04:50.538*0x14f500         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2016)
21:04:50.543*0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=2028, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=56704 scope_id=0), length=28)
21:04:50.544 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2028)

21:06:02.797*0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=2008, connect_to(AF_INET: addr=127.0.0.1 port=56757), length=16)
21:06:02.799 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2008)
21:06:02.801*0x14f500         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2016)
21:06:02.806*0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=2028, connect_to(AF_INET: addr=127.0.0.1 port=56757), length=16)
21:06:02.807 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2028)
```
AIX java_java(io) tracepoints
```
04:56:22.914 0x30010700        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0x502, sharing=0x1b6, creation=0x0, attributes=0x0, handle=6)
04:56:22.914 0x30010700        jcl_java.4         - io_createFileExclusively_close(handle=6)
04:56:22.914 0x30010700        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x301, sharing=0x1b6, creation=0x0, attributes=0x0, handle=6)
04:56:22.914 0x30010700        jcl_java.0         - io_fileDescriptorClose(handle=6)
```

AIX jcl_nio tracepoints
```
20:52:27.550*0x30010700         jcl_nio.1         - nio_ch_Net_Connect(descriptor=5, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=59536 scope_id=0), length=28)
20:52:27.555 0x30010700         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=5)
20:52:27.580 0x30010700         jcl_nio.1         - nio_ch_Net_Connect(descriptor=5, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=59536 scope_id=0), length=28)
20:52:27.581 0x30010700         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=5)

20:53:13.035*0x30010700         jcl_nio.0         - nio_ch_Net_Connect(descriptor=6, connect_to(AF_INET: addr=127.0.0.1 port=59539), length=16)
20:53:13.037 0x30010700         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=6)
20:53:13.073 0x30010700         jcl_nio.0         - nio_ch_Net_Connect(descriptor=8, connect_to(AF_INET: addr=127.0.0.1 port=59539), length=16)
20:53:13.074 0x30010700         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=8)
```

xmac jcl_java(io) tracepoints
```
14:48:34.662 0x15ea5000        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xa02, sharing=0x1b6, creation=0x0, attributes=0x0, handle=9)
14:48:34.662 0x15ea5000        jcl_java.4         - io_createFileExclusively_close(handle=9)
14:48:34.664 0x15ea5000        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x601, sharing=0x1b6, creation=0x0, attributes=0x0, handle=9)
14:48:34.664 0x15ea5000        jcl_java.0         - io_fileDescriptorClose(handle=9)
```

xmac jcl_nio tracepoints
```
14:49:04.698*0x102c3000         jcl_nio.1         - nio_ch_Net_Connect(descriptor=9, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=64865 scope_id=0), length=28)
14:49:04.703 0x102c3000         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=9)
14:49:04.862 0x102c3000         jcl_nio.1         - nio_ch_Net_Connect(descriptor=9, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=64865 scope_id=0), length=28)
14:49:04.862 0x102c3000         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=9)
14:49:04.905*0x103d5900         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=10)
14:49:04.905 0x103d5900         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=6)

14:49:47.729*0xf33d000         jcl_nio.0         - nio_ch_Net_Connect(descriptor=9, connect_to(AF_INET: addr=127.0.0.1 port=64868), length=16)
14:49:47.735 0xf33d000         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=9)
14:49:47.893 0xf33d000         jcl_nio.0         - nio_ch_Net_Connect(descriptor=9, connect_to(AF_INET: addr=127.0.0.1 port=64868), length=16)
14:49:47.893 0xf33d000         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=9)
14:49:47.900*0xf44f900         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=6)
14:49:47.900 0xf44f900         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=10)
```