### PR TITLE
Enable PBKDF2 within strict FIPS 140-3 profile

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -182,7 +182,7 @@ RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.default = false
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:255c7615e983c0a5b13a6a5fbcde19b373c182db4fbf80aac81a11954e86a80e
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:165e640b29e9a250409e353039f735c47dcd1043b056fb5ccd224698d9ae8a1e
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.number = Certificate #XXX
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.sunsetDate = 2026-09-21
@@ -275,6 +275,10 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.1 = com.ibm.crypto.plu
     {MessageDigest, SHA3-384, *}, \
     {MessageDigest, SHA3-512, *}, \
     {SecretKeyFactory, AES, *}, \
+    {SecretKeyFactory, PBKDF2WithHmacSHA224, *}, \
+    {SecretKeyFactory, PBKDF2WithHmacSHA256, *}, \
+    {SecretKeyFactory, PBKDF2WithHmacSHA384, *}, \
+    {SecretKeyFactory, PBKDF2WithHmacSHA512, *}, \
     {SecureRandom, SHA256DRBG, *}, \
     {SecureRandom, SHA512DRBG, *}, \
     {Signature, NONEwithECDSA, *}, \


### PR DESCRIPTION
The algorithms `PBKDF2WithHmacSHA224`, `PBKDF2WithHmacSHA256`, `PBKDF2WithHmacSHA384`, and `PBKDF2WithHmacSHA512` are now available in the `OpenJCEPlusFIPS` provider. This update allows for their usage in the strict 140-3 profile.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/950

Signed-off-by: Jason Katonica <katonica@us.ibm.com>