### PR TITLE
Only check and set FIPS mode in FIPS profiles

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -569,11 +569,17 @@ public final class RestrictedSecurity {
         propsMapping.put("jdk.tls.legacyAlgorithms", restricts.jdkTlsLegacyAlgorithms);
         propsMapping.put("jdk.certpath.disabledAlgorithms", restricts.jdkCertpathDisabledAlgorithms);
         propsMapping.put("jdk.security.legacyAlgorithms", restricts.jdkSecurityLegacyAlgorithms);
-        String fipsMode = System.getProperty("com.ibm.fips.mode");
-        if (fipsMode == null) {
-            System.setProperty("com.ibm.fips.mode", restricts.jdkFipsMode);
-        } else if (!fipsMode.equals(restricts.jdkFipsMode)) {
-            printStackTraceAndExit("Property com.ibm.fips.mode is incompatible with semeru.customprofile and semeru.fips properties");
+
+        if (restricts.descIsFIPS) {
+            if (restricts.jdkFipsMode == null) {
+                printStackTraceAndExit(profileID + ".fips.mode property is not set in FIPS profile");
+            }
+            String fipsMode = System.getProperty("com.ibm.fips.mode");
+            if (fipsMode == null) {
+                System.setProperty("com.ibm.fips.mode", restricts.jdkFipsMode);
+            } else if (!fipsMode.equals(restricts.jdkFipsMode)) {
+                printStackTraceAndExit("Property com.ibm.fips.mode is incompatible with semeru.customprofile and semeru.fips properties");
+            }
         }
 
         if (userEnabledFIPS && !allowSetProperties) {


### PR DESCRIPTION
A `RestrictedSecurity` profile doesn't have to be a `FIPS` profile, in which case a `FIPS mode` property is not required and the corresponding system property should not be set.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/957

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>