### PR TITLE
Add error visibility for SunPKCS11 provider configuration failures

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -39,6 +39,7 @@ import java.util.*;
 
 import java.security.*;
 
+import sun.security.util.Debug;
 import sun.security.util.PropertyExpander;
 
 import sun.security.pkcs11.wrapper.*;
@@ -1058,11 +1059,23 @@ final class Config {
 
 class ConfigurationException extends IOException {
     private static final long serialVersionUID = 254492758807673194L;
+
+    private static final Debug configDebug = Debug.getInstance("sunpkcs11");
+
+    private static void debug(String msg) {
+         // If debugging is enabled, use the Debug class for additional sunpkcs11 logging.
+         if (configDebug != null) {
+             configDebug.println(msg);
+         }
+     }
+
     ConfigurationException(String msg) {
         super(msg);
+        debug(msg);
     }
 
     ConfigurationException(String msg, Throwable e) {
         super(msg, e);
+        debug(msg);
     }
 }


### PR DESCRIPTION
When using `SunPKCS11` at the top of the security provider list, if configuration errors are present in the pkcs11 config file (e.g., a typo in the list of `disabledMechanisms{}`), the `SunPKCS11` provider fails to initialize. If the provider is unspecified during the cryptographic operation, the application continues to run without any indication of sunpkcs11 configuration issues, while moving onto the next provider in list, leading to silent initialization failures.

The lack of error messages makes it difficult for users to diagnose and fix sunpkcs11 related configuration issues. This change modifies the `ConfigurationException` class in `pkcs11/Config.java` to output error messages when
`-Djava.security.debug=sunpkcs11` debug flag is enabled, providing better visibility into initialization failures due to potential errors present in the configuration file.

Backport of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/965