### PR TITLE
Rename bundled openssl libraries

### DIFF
--- a/closed/custom/modules/java.base/Copy.gmk
+++ b/closed/custom/modules/java.base/Copy.gmk
@@ -227,7 +227,7 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
     $(error Cannot bundle OpenSSL - none of $(LIBCRYPTO_NAMES) are present in $(OPENSSL_BUNDLE_LIB_PATH))
   endif
 
-  LIBCRYPTO_TARGET_LIB := $(LIB_DST_DIR)/$(notdir $(LIBCRYPTO_PATH))
+  LIBCRYPTO_TARGET_LIB := $(LIB_DST_DIR)/$(LIBRARY_PREFIX)crypto-semeru$(SHARED_LIBRARY_SUFFIX)
   TARGETS += $(LIBCRYPTO_TARGET_LIB)
   $(LIBCRYPTO_TARGET_LIB) : $(LIBCRYPTO_PATH)
 	$(call install-file)
@@ -245,7 +245,7 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
       LIBSSL_PATH := $(firstword $(wildcard $(addprefix $(OPENSSL_BUNDLE_LIB_PATH)/, $(LIBSSL_NAMES))))
 
       ifneq ($(LIBSSL_PATH), )
-        LIBSSL_TARGET_LIB = $(LIB_DST_DIR)/$(notdir $(LIBSSL_PATH))
+        LIBSSL_TARGET_LIB = $(LIB_DST_DIR)/$(LIBRARY_PREFIX)ssl-semeru$(SHARED_LIBRARY_SUFFIX)
         TARGETS += $(LIBSSL_TARGET_LIB)
         $(LIBSSL_TARGET_LIB) : $(LIBSSL_PATH)
 			$(call install-file)

--- a/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
+++ b/closed/src/java.base/share/native/libjncrypto/NativeCrypto.c
@@ -662,6 +662,17 @@ find_crypto_library(jboolean traceEnabled, const char *chomepath)
 #endif /* defined(_AIX) */
     };
 
+    /** OpenSSL library names associated with bundled library. */
+#if defined(_AIX)
+    static const char bundledLibName[] = "libcrypto-semeru.so";
+#elif defined(__APPLE__) /* defined(_AIX) */
+    static const char bundledLibName[] = "libcrypto-semeru.dylib";
+#elif defined(_WIN32) /* defined(__APPLE__) */
+    static const char bundledLibName[] = "crypto-semeru.dll";
+#else /* defined(_WIN32) */
+    static const char bundledLibName[] = "libcrypto-semeru.so";
+#endif /* defined(_AIX) */
+
     const size_t numOfLibs = sizeof(libNames) / sizeof(libNames[0]);
     void *result = NULL;
     size_t i = 0;
@@ -675,7 +686,7 @@ find_crypto_library(jboolean traceEnabled, const char *chomepath)
         static const char pathSuffix[] = "/lib/";
 #endif /* defined(_WIN32) */
 
-        size_t path_len = strlen(chomepath) + sizeof(pathSuffix) - 1;
+        size_t path_len = strlen(chomepath) + sizeof(pathSuffix) - 1 + sizeof(bundledLibName) - 1;
         char *libPath = malloc(path_len + 1);
 
         if (NULL == libPath) {
@@ -693,33 +704,17 @@ find_crypto_library(jboolean traceEnabled, const char *chomepath)
             fprintf(stdout, "Attempting to load library bundled with JDK from: %s\n", libPath);
         }
 
-        for (i = 0; i < numOfLibs; i++) {
-            size_t file_len = strlen(libNames[i]);
-            /* Allocate memory for the new file name with the path. */
-            char *libNameWithPath = (char *)malloc(path_len + file_len + 1);
+        strcat(libPath, bundledLibName);
 
-            if (NULL == libNameWithPath) {
-                if (traceEnabled) {
-                    fprintf(stderr, "\tFailed to allocate memory for file name with path.\n");
-                }
-                continue;
-            }
+        /* Load OpenSSL Crypto library bundled with JDK. */
+        if (traceEnabled) {
+            fprintf(stdout, "\tAttempting to load: %s\n", bundledLibName);
+        }
+        result = load_crypto_library(traceEnabled, libPath);
 
-            strcpy(libNameWithPath, libPath);
-            strcat(libNameWithPath, libNames[i]);
+        free(libPath);
 
-            /* Load OpenSSL Crypto library bundled with JDK. */
-            if (traceEnabled) {
-                fprintf(stdout, "\tAttempting to load: %s\n", libNames[i]);
-            }
-            result = load_crypto_library(traceEnabled, libNameWithPath);
-
-            free(libNameWithPath);
-
-            if (NULL == result) {
-                continue;
-            }
-
+        if (NULL != result) {
             /* Identify and load the latest version from the potential libraries.
              * This logic depends upon the order in which libnames are defined.
              * Libraries are listed in descending order w.r.t version.
@@ -728,11 +723,9 @@ find_crypto_library(jboolean traceEnabled, const char *chomepath)
              */
             tempVersion = get_crypto_library_version(traceEnabled, result, "\t\tLoaded OpenSSL version");
             if (tempVersion > 0) {
-                free(libPath);
                 return result;
             }
         }
-        free(libPath);
     }
 
     /* The attempt to load from property and OpenSSL bundled with JDK failed.


### PR DESCRIPTION
OpenSSL libraries that are bundled within the runtime are being renamed to avoid conflicts with system libraries that may have the same name. Additional updates were made to the loading logic associated with native cryptography to make use of the correct bundled version by default.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/980

Signed-off-by: Jason Katonica <katonica@us.ibm.com>