### PR TITLE
Enable CRaC for all Linux platforms

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -331,12 +331,8 @@ AC_DEFUN([OPENJ9_CONFIGURE_CRAC_AND_CRIU_SUPPORT],
 
   # Compute platform-specific defaults.
   case "$OPENJ9_PLATFORM_CODE" in
-    xa64)
+    xa64|xl64|xr64|xz64)
       default_crac=yes
-      default_criu=yes
-      ;;
-    xl64|xr64|xz64)
-      default_crac=no
       default_criu=yes
       ;;
     *)


### PR DESCRIPTION
Enable `CRaC` for all Linux platforms

Cherry-pick
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/995


Signed-off-by: Jason Feng <fengj@ca.ibm.com>