### PR TITLE
Enable the use of OpenJCEPlusFIPS for HKDF operations

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/HKDF.java
+++ b/src/java.base/share/classes/sun/security/ssl/HKDF.java
@@ -23,15 +23,33 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.ssl;
 
+/*[IF OPENJCEPLUS_SUPPORT]*/
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.security.InvalidAlgorithmParameterException;
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
 import java.security.NoSuchAlgorithmException;
 import java.security.InvalidKeyException;
+/*[IF OPENJCEPLUS_SUPPORT]*/
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.KeyGenerator;
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.SecretKeySpec;
 import java.util.Objects;
+/*[IF OPENJCEPLUS_SUPPORT]*/
+import openj9.internal.security.RestrictedSecurity;
+/*[ENDIF] OPENJCEPLUS_SUPPORT */
 
 /**
  * An implementation of the HKDF key derivation algorithm outlined in RFC 5869,
@@ -47,6 +65,28 @@ final class HKDF {
     private final Mac hmacObj;
     private final int hmacLen;
 
+    /*[IF OPENJCEPLUS_SUPPORT]*/
+    private final KeyGenerator hkdfGenerator;
+    private static final Constructor<?> expandCtor;
+    private static final Constructor<?> extractCtor;
+
+    static {
+        try {
+            if (RestrictedSecurity.isFIPSEnabled()) {
+                Class<?> hkdfExpandSpec = Class.forName("ibm.security.internal.spec.HKDFExpandParameterSpec", true, ClassLoader.getSystemClassLoader());
+                expandCtor = hkdfExpandSpec.getDeclaredConstructor(SecretKey.class, byte[].class, long.class, String.class);
+                Class<?> hkdfExtractSpec = Class.forName("ibm.security.internal.spec.HKDFExtractParameterSpec", true, ClassLoader.getSystemClassLoader());
+                extractCtor = hkdfExtractSpec.getDeclaredConstructor(SecretKey.class, byte[].class, String.class);
+            } else {
+                expandCtor = null;
+                extractCtor = null;
+            }
+        } catch (ClassNotFoundException | NoSuchMethodException exc) {
+            throw new SecurityException(exc);
+        }
+    }
+    /*[ENDIF] OPENJCEPLUS_SUPPORT */
+
     /**
      * Create an HDKF object, specifying the underlying message digest
      * algorithm.
@@ -60,6 +100,14 @@ final class HKDF {
     HKDF(String hashAlg) throws NoSuchAlgorithmException {
         Objects.requireNonNull(hashAlg,
                 "Must provide underlying HKDF Digest algorithm.");
+        /*[IF OPENJCEPLUS_SUPPORT]*/
+        if (RestrictedSecurity.isFIPSEnabled()) {
+            String hkdfAlg = "kda-hkdf-with-" + hashAlg.replace("-", "").toLowerCase();
+            hkdfGenerator = KeyGenerator.getInstance(hkdfAlg);
+        } else {
+            hkdfGenerator = null;
+        }
+        /*[ENDIF] OPENJCEPLUS_SUPPORT */
         String hmacAlg = "Hmac" + hashAlg.replace("-", "");
         hmacObj = Mac.getInstance(hmacAlg);
         hmacLen = hmacObj.getMacLength();
@@ -87,6 +135,21 @@ final class HKDF {
         if (salt == null) {
             salt = new SecretKeySpec(new byte[hmacLen], "HKDF-Salt");
         }
+        /*[IF OPENJCEPLUS_SUPPORT]*/
+        if (hkdfGenerator != null) {
+            if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+                SSLLogger.info("HKDF extract in FIPS mode: Using OpenJCEPlusFIPS");
+            }
+            try {
+                AlgorithmParameterSpec hkdfParams = (AlgorithmParameterSpec) extractCtor.newInstance(inputKey, salt.getEncoded(), keyAlg);
+                hkdfGenerator.init(hkdfParams);
+                return hkdfGenerator.generateKey();
+            } catch (ClassCastException | IllegalAccessException | InstantiationException
+                    | InvalidAlgorithmParameterException | InvocationTargetException exc) {
+                throw new SecurityException(exc);
+            }
+        }
+        /*[ENDIF] OPENJCEPLUS_SUPPORT */
         hmacObj.init(salt);
 
         return new SecretKeySpec(hmacObj.doFinal(inputKey.getEncoded()),
@@ -146,6 +209,23 @@ final class HKDF {
             throw new IllegalArgumentException("Requested output length " +
                     "exceeds maximum length allowed for HKDF expansion");
         }
+
+        /*[IF OPENJCEPLUS_SUPPORT]*/
+        if (hkdfGenerator != null) {
+            if (SSLLogger.isOn && SSLLogger.isOn("ssl")) {
+                SSLLogger.info("HKDF expand in FIPS mode: Using OpenJCEPlusFIPS");
+            }
+            try {
+                AlgorithmParameterSpec hkdfParams = (AlgorithmParameterSpec) expandCtor.newInstance(pseudoRandKey, info, outLen, keyAlg);
+                hkdfGenerator.init(hkdfParams);
+                return hkdfGenerator.generateKey();
+            } catch (ClassCastException | IllegalAccessException | InstantiationException
+                    | InvalidAlgorithmParameterException | InvocationTargetException exc) {
+                throw new SecurityException(exc);
+            }
+        }
+        /*[ENDIF] OPENJCEPLUS_SUPPORT */
+
         hmacObj.init(pseudoRandKey);
         if (info == null) {
             info = new byte[0];


### PR DESCRIPTION
When in `FIPS` mode, the implementation offered by `OpenJCEPlusFIPS` should be utilized for `HKDF` operations, instead of the default one provided by `Sun`.

More specifically, instead of performing the `extract()` and `expand()` operations in `HKDF.java`, the FIPS-compliant methods offered by `OpenJCEPlusFIPS` should be called.

This change is only applicable in Java 24 and below. In Java 25, the entire `HKDF.java` class, which is used independently and not provided through the JCE framework, is removed entirely. The way `HKDF` functionality is offered is being restructured and a new `KDFSpi` is introduced. Whoever wants to provide said functionality from this point on will need to extend the `KDFSpi` and register their service through a provider.

With this new behaviour, `OpenJCEPlusFIPS` can just provide a service that extends the `KDFSpi` (see issue https://github.com/IBM/OpenJCEPlus/issues/599) and the calls for `HKDF` functionality will be appropriately directed to the FIPS-compliant module without any further changes to the `JCK` classes.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk24/pull/85

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>