### PR TITLE
Update test exclusion list for weak FIPS140-3

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -685,6 +685,7 @@ sun/security/mscapi/KeytoolChangeAlias.java https://github.com/eclipse-openj9/op
 sun/security/mscapi/NullKey.java https://github.com/eclipse-openj9/openj9/issues/20978 windows-all
 sun/security/mscapi/PrngSerialize.java https://github.com/eclipse-openj9/openj9/issues/20978 windows-all
 sun/security/mscapi/PrngSlow.java https://github.com/eclipse-openj9/openj9/issues/20978 windows-all
+sun/security/mscapi/nonUniqueAliases/NonUniqueAliases.java https://github.com/eclipse-openj9/openj9/issues/20978 windows-all
 sun/security/pkcs/pkcs10/PKCS10AttrEncoding.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/pkcs/pkcs7/PKCS7VerifyTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/pkcs/pkcs7/SignerOrder.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
This commit updates the test exclude list for FIPS140-3 weak profile.