### PR TITLE
Update the exclusion list for the FIPS 140-3 Strict profile

### DIFF
--- a/test/jdk/ProblemList-FIPS140_2.txt
+++ b/test/jdk/ProblemList-FIPS140_2.txt
@@ -879,7 +879,7 @@ sun/security/pkcs/pkcs8/PKCS8Test.java https://github.com/ibmruntimes/openj9-ope
 sun/security/pkcs/pkcs8/TestLeadingZeros.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x
 sun/security/pkcs12/Bug6415637.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x
 sun/security/pkcs12/EmptyPassword.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x
-sun/security/pkcs12/KeytoolOpensslInteropTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x
+sun/security/pkcs12/KeytoolOpensslInteropTest.java#UseExistingPKCS12 https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x
 sun/security/pkcs12/P12SecretKey.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x
 sun/security/pkcs12/PBES2Encoding.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x
 sun/security/pkcs12/PKCS12SameKeyId.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-x64,linux-ppc64le,linux-s390x

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
@@ -777,7 +777,7 @@ sun/security/pkcs12/AttributesMultiThread.java https://github.com/eclipse-openj9
 sun/security/pkcs12/Bug6415637.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/EmptyPassword.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/GetSetEntryTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-sun/security/pkcs12/KeytoolOpensslInteropTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs12/KeytoolOpensslInteropTest.java#UseExistingPKCS12 https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/P12SecretKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/PBES2Encoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/PKCS12SameKeyId.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -775,7 +775,7 @@ sun/security/pkcs12/AttributesMultiThread.java https://github.com/eclipse-openj9
 sun/security/pkcs12/Bug6415637.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/EmptyPassword.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/GetSetEntryTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-sun/security/pkcs12/KeytoolOpensslInteropTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs12/KeytoolOpensslInteropTest.java#UseExistingPKCS12 https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/P12SecretKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/PBES2Encoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/PKCS12SameKeyId.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -698,7 +698,7 @@ sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java https://github.com/eclipse-
 sun/security/pkcs11/tls/tls12/FipsModeTLS12.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/pkcs12/Bug6415637.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/pkcs12/EmptyPassword.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
-sun/security/pkcs12/KeytoolOpensslInteropTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/pkcs12/KeytoolOpensslInteropTest.java#UseExistingPKCS12 https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/pkcs12/P12SecretKey.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/pkcs12/PBES2Encoding.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/pkcs12/PKCS12SameKeyId.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
This is a back port PR from PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1066

This commit updates a test in the FIPS 140-3 Strict profile exclusion list, including the full test case name.