### PR TITLE
Update FIPS exclusion list for .56 release

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -160,6 +160,7 @@ com/sun/jndi/ldap/LdapPoolTimeoutTest.java https://github.ibm.com/runtimes/backl
 com/sun/jndi/ldap/LdapSSLHandshakeFailureTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/jndi/ldap/LdapTimeoutTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 com/sun/jndi/rmi/registry/objects/ObjectFactoryBuilderCodebaseTest.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+com/sun/jndi/rmi/registry/objects/RmiFactoriesFilterTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/jndi/rmi/registry/RegistryContext/ContextWithNullProperties.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/jndi/rmi/registry/RegistryContext/UnbindIdempotent.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/org/apache/xml/internal/security/ShortECDSA.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -486,7 +487,7 @@ javax/net/ssl/ServerName/EndingDotHostname.java https://github.com/eclipse-openj
 javax/net/ssl/ServerName/SSLEngineExplorer.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ServerName/SSLEngineExplorerMatchedSNI.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ServerName/SSLEngineExplorerUnmatchedSNI.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java https://github.com/eclipse-openj9/openj9/issues/20343 windows-all
+javax/net/ssl/ServerName/SSLEngineExplorerWithCli.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ServerName/SSLEngineExplorerWithSrv.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ServerName/SSLSocketConsistentSNI.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/ServerName/SSLSocketExplorer.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -920,6 +921,7 @@ sun/security/ssl/SignatureScheme/CustomizedServerSchemes.java https://github.com
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeDTLS12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS13.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SignatureScheme/MD5NotAllowedInTLS13CertificateSignature.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/MixingTLSUsageConstraintsWithNonTLS.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS13.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -958,6 +960,8 @@ sun/security/ssl/SSLEngineImpl/SSLEngineDeadlock.java https://github.com/eclipse
 sun/security/ssl/SSLEngineImpl/SSLEngineDecodeBadPoint.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/ssl/SSLEngineImpl/SSLEngineFailedALPN.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLEngineImpl/SSLEngineKeyLimit.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SSLEngineImpl/TestBadDNForPeerCA.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SSLEngineImpl/TestBadDNForPeerCA12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLEngineImpl/TLS13BeginHandshake.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLLogger/DebugPropertyValuesTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLLogger/LoggingFormatConsistency.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -810,6 +810,7 @@ sun/security/ssl/SignatureScheme/CustomizedServerSchemes.java https://github.com
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeDTLS12.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS12.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS13.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/ssl/SignatureScheme/MD5NotAllowedInTLS13CertificateSignature.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/MixingTLSUsageConstraintsWithNonTLS.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS12.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS13.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
Some tests listed in the JDK Next exclusion list were not backported to earlier JDK versions, likely because the tests themselves had not been backported at that time.

Now, these tests need to be added to the exclusion lists for earlier JDK versions because:

1. The tests have since been backported, or
2. They are not yet backported, but once they are, they will inevitably fail since the required algorithms are not supported in FIPS mode.