### PR TITLE
SHA1withECDSA is not required for ECDHE and ECDSA

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/JsseJce.java
+++ b/src/java.base/share/classes/sun/security/ssl/JsseJce.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,7 +166,6 @@ final class JsseJce {
         static {
             boolean mediator = true;
             try {
-                Signature.getInstance(SIGNATURE_ECDSA);
                 Signature.getInstance(SIGNATURE_RAWECDSA);
                 KeyAgreement.getInstance("ECDH");
                 KeyFactory.getInstance("EC");


### PR DESCRIPTION
This removes the requirement that SHA1withECDSA be present for EC cryptography to become available in a TLS connection. In the case of using FIPS 140-3 we should only enforce that NONEwithECDSA be available.

Back-port of: 8373408: SHA1withECDSA is not required for ECDHE and ECDSA https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/467b02164317b7253a8dec5f79f6f5ffb8cf9c66

Signed-off-by: Jason Katonica <katonica@us.ibm.com>