### PR TITLE
Update exclude list for FIPS 140-3 profile testing

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
@@ -69,6 +69,7 @@ com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20Poly1305ParamTest.java https://g
 com/sun/crypto/provider/Cipher/ChaCha20/OutputSizeTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/ChaCha20/unittest/ChaCha20CipherUnitTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/ChaCha20/unittest/ChaCha20Poly1305ParametersUnitTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+com/sun/crypto/provider/Cipher/ChaCha20/UpdateAADTest.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 com/sun/crypto/provider/Cipher/CTR/CounterMode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/CTS/CTSMode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/DES/DesAPITest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -83,6 +84,8 @@ com/sun/crypto/provider/Cipher/DES/Sealtest.java https://github.com/eclipse-open
 com/sun/crypto/provider/Cipher/DES/TestCipherDES.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/DES/TestCipherDESede.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/DES/TextPKCS5PaddingTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+com/sun/crypto/provider/Cipher/HPKE/Compliance.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+com/sun/crypto/provider/Cipher/HPKE/Functions.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 com/sun/crypto/provider/Cipher/JCE/Bugs/4686632/Empty.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/KeyWrap/NISTWrapKAT.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -286,6 +289,7 @@ java/security/KeyStore/PKCS12/ReadP12Test.java https://github.com/eclipse-openj9
 java/security/KeyStore/PKCS12/UnmodifiableAttributes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/PKCS12/WriteP12Test.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/ProbeKeystores.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/KeyStore/TestDisabledAlgorithms.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 java/security/KeyStore/TestKeyStoreBasic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/TestKeyStoreEntry.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/MessageDigest/ArgumentSanity.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -336,6 +340,7 @@ java/security/Security/ConfigFileTest.java https://github.com/eclipse-openj9/ope
 java/security/Security/ProviderFiltering.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/removing/RemoveProviderByIdentity.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/removing/RemoveStaticProvider.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/Security/SecurityPropFile/ExtraFileAndIncludes.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 java/security/Security/signedfirst/DynStatic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Signature/ByteBuffers.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Signature/NONEwithRSA.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -361,16 +366,19 @@ javax/crypto/Cipher/GetMaxAllowed.java https://github.com/eclipse-openj9/openj9/
 javax/crypto/Cipher/InOutBuffers.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/Cipher/InvalidKeyExceptionTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/Cipher/TestCipherMode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/crypto/Cipher/TestDisabledAlgorithms.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/crypto/Cipher/TestGetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/Cipher/Turkish.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CipherSpi/DirectBBRemaining.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CryptoPermission/RC4AliasPermCheck.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CryptoPermission/RSANoLimit.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CryptoPermissions/InconsistentEntries.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+javax/crypto/EncryptedPrivateKeyInfo/Encrypt.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/EncryptKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetAlgName.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetEncoded.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/crypto/EncryptedPrivateKeyInfo/GetKeyPair.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpec.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException2.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -415,6 +423,7 @@ javax/net/ssl/DTLS/DTLSHandshakeWithReplicatedPacketsTest.java https://github.co
 javax/net/ssl/DTLS/DTLSIncorrectAppDataTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/DTLSMFLNTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/DTLSNamedGroups.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/net/ssl/DTLS/DTLSNoNewSessionTicket.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/net/ssl/DTLS/DTLSNotEnabledRC4Test.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/DTLSOverDatagram.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/DTLSRehandshakeTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -452,7 +461,9 @@ javax/net/ssl/FixingJavadocs/ImplicitHandshake.java https://github.com/eclipse-o
 javax/net/ssl/FixingJavadocs/KMTMGetNothing.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/FixingJavadocs/SSLSessionNulls.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/FixingJavadocs/SSLSocketInherit.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java#tls12 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java#tls13 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/net/ssl/HttpsURLConnection/GetResponseCode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/interop/ClientHelloBufferUnderflowException.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/interop/ClientHelloChromeInterOp.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -739,6 +750,7 @@ sun/security/mscapi/NullKey.java https://github.com/eclipse-openj9/openj9/issues
 sun/security/mscapi/PrngSerialize.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/mscapi/PrngSlow.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs10/PKCS10AttrEncoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs/pkcs7/MLDSADigestConformance.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/pkcs/pkcs7/PKCS7VerifyTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs7/SignerOrder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs8/LongPKCS8orX509KeySpec.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -757,6 +769,7 @@ sun/security/pkcs12/AttributesMultiThread.java https://github.com/eclipse-openj9
 sun/security/pkcs12/GetSetEntryTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/P12SecretKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/PBES2Encoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs12/PBMAC1Test.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/pkcs12/PKCS12SameKeyId.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/SecretKeyAlgorithms.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/StorePasswordTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -876,6 +889,10 @@ sun/security/ssl/ServerHandshaker/GetPeerHost.java https://github.com/eclipse-op
 sun/security/ssl/ServerHandshaker/HelloExtensionsTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/CustomizedClientSchemes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/CustomizedServerSchemes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SignatureScheme/DefaultSSLConfigSignatureSchemes.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/SignatureScheme/DisableCertSignAlgsExtForClientTLS12.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/SignatureScheme/DisableCertSignAlgsExtForClientTLS13.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/SignatureScheme/DisableCertSignAlgsExtForServerTLS13.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/SignatureScheme/DisableSHA1inHandshakeSignatureDTLS12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/DisableSHA1inHandshakeSignatureTLS12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/DisableSHA1inHandshakeSignatureTLS13.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -884,6 +901,7 @@ sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS12.java https:
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS13.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/MD5NotAllowedInTLS13CertificateSignature.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/MixingTLSUsageConstraintsWithNonTLS.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SignatureScheme/RsaSsaPssConstraints.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS13.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/SigSchemePropOrdering.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -924,6 +942,7 @@ sun/security/ssl/SSLEngineImpl/SSLEngineKeyLimit.java https://github.com/eclipse
 sun/security/ssl/SSLEngineImpl/TestBadDNForPeerCA.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLEngineImpl/TestBadDNForPeerCA12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLEngineImpl/TLS13BeginHandshake.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SSLEngineImpl/TLS13ChangeCipherSpecAfterFinished.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/SSLLogger/DebugPropertyValuesTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLLogger/LoggingFormatConsistency.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSessionContextImpl/DefautlCacheSize.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -978,10 +997,13 @@ sun/security/ssl/Stapling/StatusResponseManager.java https://github.com/eclipse-
 sun/security/ssl/X509KeyManager/AlgorithmConstraintsCheck.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509KeyManager/CertChecking.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509KeyManager/CertificateAuthorities.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/X509KeyManager/NonExtendedSSLSessionAlgorithmConstraints.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509KeyManager/PeerConstraintsCheck.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509KeyManager/PreferredKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509KeyManager/SelectOneKeyOutOfMany.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/X509KeyManager/X509KeyManagerNegativeTests.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509TrustManagerImpl/BasicConstraints.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/X509TrustManagerImpl/CertChainAlgorithmConstraints.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509TrustManagerImpl/CertRequestOverflow.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509TrustManagerImpl/CheckNullEntity.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509TrustManagerImpl/ComodoHacker.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -996,6 +1018,7 @@ sun/security/tools/jarsigner/EntriesOrder.java https://github.com/eclipse-openj9
 sun/security/tools/jarsigner/JarSigningNonAscii.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/LargeJarEntry.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/LineBrokenMultiByteCharacter.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/tools/jarsigner/ML_DSA.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/tools/jarsigner/multiRelease/MVJarSigningTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/Options.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1016,7 +1039,9 @@ sun/security/tools/keytool/HasSrcStoretypeOption.java https://github.com/eclipse
 sun/security/tools/keytool/ImportPrompt.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/KeyToolTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/NewSize7.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/tools/keytool/OutdatedKeyStoreWarning.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/tools/keytool/PKCS12Passwd.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/tools/keytool/SetInPassword.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/tools/keytool/StartDateTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/StorePasswords.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/UnknownAndUnparseable.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1033,6 +1058,7 @@ sun/security/util/HostnameMatcher/NullHostnameCheck.java https://github.com/ecli
 sun/security/util/InternalPrivateKey/Correctness.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/util/Pem/PemEncoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/util/Resources/early/EarlyResources.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+sun/security/util/SliceableSecretKey/SoftSliceable.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/validator/CertReplace.java#certreplace https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/validator/CertReplace.java#samedn https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/validator/certreplace.sh https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1048,7 +1074,11 @@ sun/security/x509/EDIPartyName/NullName.java https://github.com/eclipse-openj9/o
 sun/security/x509/Extensions/IllegalExtensions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/OtherName/Parse.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/URICertStore/AIACertTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-sun/security/x509/URICertStore/CRLReadTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/x509/URICertStore/CRLReadTimeout.java#0 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/x509/URICertStore/CRLReadTimeout.java#1 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/x509/URICertStore/CRLReadTimeout.java#2 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/x509/URICertStore/CRLReadTimeout.java#3 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/x509/URICertStore/CRLReadTimeout.java#4 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/x509/URICertStore/ExtensionsWithLDAP.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/X509CertImpl/CertExtensions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/X509CertImpl/V3Certificate.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -70,6 +70,7 @@ com/sun/crypto/provider/Cipher/ChaCha20/ChaCha20Poly1305ParamTest.java https://g
 com/sun/crypto/provider/Cipher/ChaCha20/OutputSizeTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/ChaCha20/unittest/ChaCha20CipherUnitTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/ChaCha20/unittest/ChaCha20Poly1305ParametersUnitTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+com/sun/crypto/provider/Cipher/ChaCha20/UpdateAADTest.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 com/sun/crypto/provider/Cipher/CTR/CounterMode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/CTS/CTSMode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/DES/DesAPITest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -84,6 +85,8 @@ com/sun/crypto/provider/Cipher/DES/Sealtest.java https://github.com/eclipse-open
 com/sun/crypto/provider/Cipher/DES/TestCipherDES.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/DES/TestCipherDESede.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/DES/TextPKCS5PaddingTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+com/sun/crypto/provider/Cipher/HPKE/Compliance.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+com/sun/crypto/provider/Cipher/HPKE/Functions.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 com/sun/crypto/provider/Cipher/JCE/Bugs/4686632/Empty.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/KeyWrap/NISTWrapKAT.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -348,6 +351,7 @@ java/security/KeyStore/PKCS12/StoreTrustedCertKeytool.java https://github.com/ec
 java/security/KeyStore/PKCS12/UnmodifiableAttributes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/PKCS12/WriteP12Test.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/ProbeKeystores.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/KeyStore/TestDisabledAlgorithms.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 java/security/KeyStore/TestKeyStoreBasic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/TestKeyStoreEntry.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/MessageDigest/ArgumentSanity.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -399,6 +403,7 @@ java/security/Security/ConfigFileTest.java https://github.com/eclipse-openj9/ope
 java/security/Security/ProviderFiltering.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/removing/RemoveProviderByIdentity.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Security/removing/RemoveStaticProvider.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/Security/SecurityPropFile/ExtraFileAndIncludes.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 java/security/Security/signedfirst/DynStatic.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Signature/ByteBuffers.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/Signature/NONEwithRSA.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -442,6 +447,8 @@ javax/crypto/Cipher/GetMaxAllowed.java https://github.com/eclipse-openj9/openj9/
 javax/crypto/Cipher/InOutBuffers.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/Cipher/InvalidKeyExceptionTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/Cipher/TestCipherMode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/crypto/Cipher/TestDisabledAlgorithms.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+javax/crypto/Cipher/TestEmptyModePadding.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/crypto/Cipher/TestGetInstance.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/Cipher/Turkish.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CipherSpi/DirectBBRemaining.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -452,10 +459,12 @@ javax/crypto/CryptoPermission/RC2PermCheck.java https://github.com/eclipse-openj
 javax/crypto/CryptoPermission/RC4AliasPermCheck.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CryptoPermission/RSANoLimit.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/CryptoPermissions/InconsistentEntries.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+javax/crypto/EncryptedPrivateKeyInfo/Encrypt.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/EncryptKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetAlgName.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetEncoded.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/crypto/EncryptedPrivateKeyInfo/GetKeyPair.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpec.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/crypto/EncryptedPrivateKeyInfo/GetKeySpecException2.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -503,6 +512,7 @@ javax/net/ssl/DTLS/DTLSHandshakeWithReplicatedPacketsTest.java https://github.co
 javax/net/ssl/DTLS/DTLSIncorrectAppDataTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/DTLSMFLNTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/DTLSNamedGroups.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/net/ssl/DTLS/DTLSNoNewSessionTicket.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/net/ssl/DTLS/DTLSNotEnabledRC4Test.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/DTLSOverDatagram.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/DTLS/DTLSRehandshakeTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -540,7 +550,9 @@ javax/net/ssl/FixingJavadocs/ImplicitHandshake.java https://github.com/eclipse-o
 javax/net/ssl/FixingJavadocs/KMTMGetNothing.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/FixingJavadocs/SSLSessionNulls.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/FixingJavadocs/SSLSocketInherit.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java#tls12 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java#tls13 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/net/ssl/HttpsURLConnection/DummyCacheResponse.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/HttpsURLConnection/Equals.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/HttpsURLConnection/GetResponseCode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -871,6 +883,7 @@ sun/security/mscapi/NullKey.java https://github.com/eclipse-openj9/openj9/issues
 sun/security/mscapi/PrngSerialize.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/mscapi/PrngSlow.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs10/PKCS10AttrEncoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs/pkcs7/MLDSADigestConformance.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/pkcs/pkcs7/PKCS7VerifyTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs7/SignerOrder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs/pkcs8/LongPKCS8orX509KeySpec.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -900,6 +913,7 @@ sun/security/pkcs12/KeytoolOpensslInteropTest.java#UseExistingPKCS12 https://git
 sun/security/pkcs12/MixedcaseAlias.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/pkcs12/P12SecretKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/PBES2Encoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/pkcs12/PBMAC1Test.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/pkcs12/PKCS12SameKeyId.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/ProbeBER.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/pkcs12/ProbeLargeKeystore.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1027,6 +1041,10 @@ sun/security/ssl/ServerHandshaker/GetPeerHost.java https://github.com/eclipse-op
 sun/security/ssl/ServerHandshaker/HelloExtensionsTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/CustomizedClientSchemes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/CustomizedServerSchemes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SignatureScheme/DefaultSSLConfigSignatureSchemes.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/SignatureScheme/DisableCertSignAlgsExtForClientTLS12.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/SignatureScheme/DisableCertSignAlgsExtForClientTLS13.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/SignatureScheme/DisableCertSignAlgsExtForServerTLS13.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/SignatureScheme/DisableSHA1inHandshakeSignatureDTLS12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/DisableSHA1inHandshakeSignatureTLS12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/DisableSHA1inHandshakeSignatureTLS13.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1035,6 +1053,7 @@ sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS12.java https:
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS13.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/MD5NotAllowedInTLS13CertificateSignature.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/MixingTLSUsageConstraintsWithNonTLS.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SignatureScheme/RsaSsaPssConstraints.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS13.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SignatureScheme/SigSchemePropOrdering.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1076,6 +1095,7 @@ sun/security/ssl/SSLEngineImpl/SSLEngineKeyLimit.java https://github.com/eclipse
 sun/security/ssl/SSLEngineImpl/TestBadDNForPeerCA.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLEngineImpl/TestBadDNForPeerCA12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLEngineImpl/TLS13BeginHandshake.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SSLEngineImpl/TLS13ChangeCipherSpecAfterFinished.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/SSLLogger/DebugPropertyValuesTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLLogger/LoggingFormatConsistency.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSessionContextImpl/DefautlCacheSize.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1129,17 +1149,25 @@ sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java https://
 sun/security/ssl/SSLSocketImpl/SSLSocketSSLEngineCloseInbound.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/UnconnectedSocketWrongExceptions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/Stapling/StatusResponseManager.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/X509KeyManager/AlgorithmConstraintsCheck.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/X509KeyManager/CertChecking.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509KeyManager/CertificateAuthorities.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509KeyManager/NoGoodKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/X509KeyManager/NonExtendedSSLSessionAlgorithmConstraints.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/X509KeyManager/NullCases.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/X509KeyManager/PeerConstraintsCheck.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509KeyManager/PreferredKey.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509KeyManager/SelectOneKeyOutOfMany.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/X509KeyManager/X509KeyManagerNegativeTests.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509TrustManagerImpl/BasicConstraints.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509TrustManagerImpl/BasicConstraints12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509TrustManagerImpl/CacertsLimit.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/X509TrustManagerImpl/CertChainAlgorithmConstraints.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509TrustManagerImpl/CertRequestOverflow.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509TrustManagerImpl/CheckNullEntity.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509TrustManagerImpl/ComodoHacker.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509TrustManagerImpl/distrust/Camerfirma.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+sun/security/ssl/X509TrustManagerImpl/distrust/Chunghwa.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509TrustManagerImpl/distrust/Entrust.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/ssl/X509TrustManagerImpl/Entrust/Distrust.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/X509TrustManagerImpl/PKIXExtendedTM.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1153,6 +1181,7 @@ sun/security/tools/jarsigner/EntriesOrder.java https://github.com/eclipse-openj9
 sun/security/tools/jarsigner/JarSigningNonAscii.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/LargeJarEntry.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/LineBrokenMultiByteCharacter.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/tools/jarsigner/ML_DSA.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/tools/jarsigner/multiRelease/MVJarSigningTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/Options.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1179,9 +1208,11 @@ sun/security/tools/keytool/ImportPrompt.java https://github.com/eclipse-openj9/o
 sun/security/tools/keytool/JKStoPKCS12.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/KeyToolTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/NewSize7.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/tools/keytool/OutdatedKeyStoreWarning.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/tools/keytool/PKCS12Passwd.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/PrintSSL.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/Serial64.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/tools/keytool/SetInPassword.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/tools/keytool/StartDateTest.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/StorePasswords.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/tools/keytool/UnknownAndUnparseable.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1199,6 +1230,7 @@ sun/security/util/InternalPrivateKey/Correctness.java https://github.com/eclipse
 sun/security/util/Oid/S11N.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/util/Pem/PemEncoding.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/util/Resources/early/EarlyResources.java https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
+sun/security/util/SliceableSecretKey/SoftSliceable.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/validator/CertReplace.java#certreplace https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/validator/CertReplace.java#samedn https://github.ibm.com/runtimes/backlog/issues/1089 generic-all
 sun/security/validator/certreplace.sh https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -1215,7 +1247,11 @@ sun/security/x509/EDIPartyName/NullName.java https://github.com/eclipse-openj9/o
 sun/security/x509/Extensions/IllegalExtensions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/OtherName/Parse.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/URICertStore/AIACertTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
-sun/security/x509/URICertStore/CRLReadTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/x509/URICertStore/CRLReadTimeout.java#0 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/x509/URICertStore/CRLReadTimeout.java#1 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/x509/URICertStore/CRLReadTimeout.java#2 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/x509/URICertStore/CRLReadTimeout.java#3 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/x509/URICertStore/CRLReadTimeout.java#4 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/x509/URICertStore/ExtensionsWithLDAP.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/X509CertImpl/CertExtensions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/x509/X509CertImpl/ECSigParamsVerifyWithCert.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -350,6 +350,7 @@ java/security/Security/ClassLoaderDeadlock/Deadlock.sh https://github.com/eclips
 java/security/Security/ConfigFileTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Security/ProviderFiltering.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Security/removing/RemoveProviderByIdentity.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+java/security/Security/SecurityPropFile/ExtraFileAndIncludes.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 java/security/Security/signedfirst/DynStatic.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Signature/ByteBuffers.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 java/security/Signature/NONEwithRSA.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
@@ -478,7 +479,8 @@ javax/net/ssl/FixingJavadocs/ImplicitHandshake.java https://github.com/eclipse-o
 javax/net/ssl/FixingJavadocs/KMTMGetNothing.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/FixingJavadocs/SSLSessionNulls.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/FixingJavadocs/SSLSocketInherit.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
-javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+javax/net/ssl/HttpsURLConnection/CriticalSubjectAltName.java#tls12 https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/net/ssl/HttpsURLConnection/DummyCacheResponse.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/HttpsURLConnection/Equals.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 javax/net/ssl/HttpsURLConnection/GetResponseCode.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
@@ -801,6 +803,7 @@ sun/security/pkcs11/Cipher/TestRSACipher.java https://github.com/eclipse-openj9/
 sun/security/pkcs11/Cipher/TestRSACipherWrap.java https://github.com/eclipse-openj9/openj9/issues/20978 linux-ppc64le,linux-s390x,linux-x64
 sun/security/pkcs11/Cipher/TestSymmCiphers.java https://github.com/eclipse-openj9/openj9/issues/20978 linux-ppc64le,linux-s390x,linux-x64
 sun/security/pkcs11/Cipher/TestSymmCiphersNoPad.java https://github.com/eclipse-openj9/openj9/issues/20978 linux-ppc64le,linux-s390x,linux-x64
+sun/security/pkcs11/Config/ReadConfInUTF16Env.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/pkcs11/ec/ReadCertificates.java https://github.com/eclipse-openj9/openj9/issues/20978 linux-ppc64le,linux-s390x,linux-x64
 sun/security/pkcs11/ec/ReadPKCS12.java https://github.com/eclipse-openj9/openj9/issues/20978 linux-ppc64le,linux-s390x,linux-x64
 sun/security/pkcs11/ec/TestCurves.java https://github.com/eclipse-openj9/openj9/issues/20978 linux-ppc64le,linux-s390x,linux-x64
@@ -987,12 +990,16 @@ sun/security/ssl/ServerHandshaker/GetPeerHost.java https://github.com/eclipse-op
 sun/security/ssl/ServerHandshaker/HelloExtensionsTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/CustomizedClientSchemes.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/CustomizedServerSchemes.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/ssl/SignatureScheme/DefaultSSLConfigSignatureSchemes.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/SignatureScheme/DisableCertSignAlgsExtForClientTLS12.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+sun/security/ssl/SignatureScheme/DisableCertSignAlgsExtForClientTLS13.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/SignatureScheme/DisableSHA1inHandshakeSignatureTLS13.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeDTLS12.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS12.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/DisableSignatureSchemePerScopeTLS13.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/MD5NotAllowedInTLS13CertificateSignature.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/MixingTLSUsageConstraintsWithNonTLS.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/ssl/SignatureScheme/RsaSsaPssConstraints.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS12.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/SigAlgosExtTestWithTLS13.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SignatureScheme/SigSchemePropOrdering.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
@@ -1079,13 +1086,16 @@ sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java https://
 sun/security/ssl/SSLSocketImpl/SSLSocketSSLEngineCloseInbound.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SSLSocketImpl/UnconnectedSocketWrongExceptions.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/Stapling/StatusResponseManager.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/ssl/X509KeyManager/AlgorithmConstraintsCheck.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509KeyManager/CertificateAuthorities.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/X509KeyManager/NoGoodKey.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/X509KeyManager/PreferredKey.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/X509KeyManager/SelectOneKeyOutOfMany.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/ssl/X509KeyManager/X509KeyManagerNegativeTests.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509TrustManagerImpl/BasicConstraints.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/X509TrustManagerImpl/BasicConstraints12.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/X509TrustManagerImpl/CacertsLimit.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/ssl/X509TrustManagerImpl/CertChainAlgorithmConstraints.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/ssl/X509TrustManagerImpl/CertRequestOverflow.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/X509TrustManagerImpl/CheckNullEntity.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/X509TrustManagerImpl/ComodoHacker.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
@@ -1136,6 +1146,7 @@ sun/security/util/Debug/DebugOptions.java https://github.com/eclipse-openj9/open
 sun/security/util/HostnameChecker/NullHostnameCheck.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/util/HostnameMatcher/NullHostnameCheck.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/util/InternalPrivateKey/Correctness.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/util/SliceableSecretKey/SoftSliceable.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 sun/security/validator/certreplace.sh https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/validator/EndEntityExtensionCheck.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/validator/samedn.sh https://github.com/eclipse-openj9/openj9/issues/20978 generic-all

--- a/test/jdk/ProblemList-OpenJCEPlus.txt
+++ b/test/jdk/ProblemList-OpenJCEPlus.txt
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2025, 2026 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -20,7 +20,12 @@
 #
 # Exclude tests list from jdk_security tests
 #
+com/sun/crypto/provider/Cipher/ChaCha20/UpdateAADTest.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
+com/sun/crypto/provider/Cipher/KeyWrap/TestCipherKeyWrapperTest.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
 com/sun/crypto/provider/DHKEM/Compliance.java https://github.ibm.com/runtimes/jit-crypto/issues/773 generic-all
+com/sun/crypto/provider/KDF/HKDFExhaustiveTest.java https://github.ibm.com/runtimes/jit-crypto/issues/773 generic-all
+java/security/PEM/PEMDecoderTest.java https://github.ibm.com/runtimes/jit-crypto/issues/773 generic-all
+java/security/PEM/PEMEncoderTest.java https://github.ibm.com/runtimes/jit-crypto/issues/773 generic-all
 java/security/Provider/SecurityProviderModularTest.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
 java/security/SecureRandom/DefaultAlgo.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
 java/security/SecureRandom/DefaultProvider.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
@@ -29,11 +34,14 @@ java/security/Security/ProviderFiltering.java https://github.ibm.com/runtimes/ji
 java/security/Signature/SignatureGetInstance.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
 java/security/Signature/SignatureLength.java https://github.ibm.com/runtimes/jit-crypto/issues/778 generic-all
 java/security/Signature/SignWithOutputBuffer.java https://github.ibm.com/runtimes/jit-crypto/issues/761 generic-all
+javax/crypto/Cipher/TestGetInstance.java https://github.com/eclipse-openj9/openj9/issues/23424 generic-all
 javax/crypto/KDF/KDFDelayedProviderException.java https://github.ibm.com/runtimes/jit-crypto/issues/779 generic-all
 javax/crypto/KDF/KDFDelayedProviderTest.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
 javax/crypto/KeyGenerator/CompareKeys.java https://github.ibm.com/runtimes/jit-crypto/issues/779 generic-all
 sun/security/ec/ed/TestEdDSA.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
 sun/security/jca/PreferredProviderNegativeTest.java https://github.com/ibmruntimes/openj9-openjdk-jdk/issues/994 generic-all
 sun/security/krb5/auto/principalProperty/PrincipalSystemPropTest.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
+sun/security/mscapi/EncodingMutability.java https://github.com/eclipse-openj9/openj9/issues/22242 windows-all
+sun/security/provider/all/Deterministic.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
 sun/security/provider/DSA/TestMaxLengthDER.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
 sun/security/util/Debug/DebugOptions.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all


### PR DESCRIPTION
Add multiple tests to the exclusion list for FIPS 140-3 profile testing across all JDK versions.

The excluded tests depend on functionality that is restricted or unavailable under FIPS 140-3 enforcement, including:

- Programmatic modification of restricted security properties
- Use of non-approved or unsupported algorithms
- Unsupported keystore types in FIPS profiles
- PKCS11 provider unavailability in 140-3 mode

These failures are expected under FIPS 140-3 enforcement and the affected tests have been added to the exclusion list.

This is a back port PR from PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1183