### PR TITLE
Remove TestMaxLengthDER test from exclude lists

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -899,7 +899,6 @@ sun/security/provider/DSA/TestDSA.java https://github.com/eclipse-openj9/openj9/
 sun/security/provider/DSA/TestDSA2.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/DSA/TestKeyPairGenerator.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/DSA/TestLegacyDSAKeyPairGenerator.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
-sun/security/provider/DSA/TestMaxLengthDER.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/hss/TestHSS.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/KeyStore/CaseSensitiveAliases.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/KeyStore/DksWithEmptyKeystore.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all

--- a/test/jdk/ProblemList-OpenJCEPlus.txt
+++ b/test/jdk/ProblemList-OpenJCEPlus.txt
@@ -43,5 +43,4 @@ sun/security/jca/PreferredProviderNegativeTest.java https://github.com/ibmruntim
 sun/security/krb5/auto/principalProperty/PrincipalSystemPropTest.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
 sun/security/mscapi/EncodingMutability.java https://github.com/eclipse-openj9/openj9/issues/22242 windows-all
 sun/security/provider/all/Deterministic.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
-sun/security/provider/DSA/TestMaxLengthDER.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all
 sun/security/util/Debug/DebugOptions.java https://github.com/eclipse-openj9/openj9/issues/22242 generic-all


### PR DESCRIPTION
After a change made in the `OpenJCEPlus` providers (see https://github.com/IBM/OpenJCEPlus/pull/770), the
`TestMaxLengthDER` test can now be properly run, so it is removed from the appropriate excludes lists.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1188

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>