### PR TITLE
AIX: Use LDR_CNTRL to specify 64kB pages

### DIFF
--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2020, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2020, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -307,13 +307,13 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     int argc = *pargc;
     char **argv = *pargv;
 
-#ifdef AIX
+#if defined(AIX)
     const char *mallocOptionsName = "MALLOCOPTIONS";
     const char *mallocOptionsValue = "multiheap,considersize";
     if (setenv(mallocOptionsName, mallocOptionsValue, 0) != 0) {
         fprintf(stderr, "setenv('MALLOCOPTIONS=multiheap,considersize') failed: performance may be affected\n");
     }
-#endif
+#endif /* defined(AIX) */
 
 #ifdef SETENV_REQUIRED
     jboolean mustsetenv = JNI_FALSE;
@@ -382,16 +382,21 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
          * any.
          */
 
-#ifdef AIX
+#if defined(AIX)
         int aixargc = *pargc - 1; // skip the launcher name
         char **aixargv = *pargv + 1;
         const char *aixarg = NULL;
+        jboolean setLDR_CNTRL = JNI_TRUE;
         jboolean useZlibNX = JNI_FALSE;
         while (aixargc > 0 && *(aixarg = *aixargv) == '-') {
             if (JLI_StrCmp(aixarg, "-XX:+UseZlibNX") == 0) {
                 useZlibNX = JNI_TRUE;
             } else if (JLI_StrCmp(aixarg, "-XX:-UseZlibNX") == 0) {
                 useZlibNX = JNI_FALSE;
+            } else if (JLI_StrCmp(aixarg, "-XX:+UseMediumPageSize") == 0) {
+                setLDR_CNTRL = JNI_TRUE;
+            } else if (JLI_StrCmp(aixarg, "-XX:-UseMediumPageSize") == 0) {
+                setLDR_CNTRL = JNI_FALSE;
             }
             aixargc--;
             aixargv++;
@@ -403,7 +408,17 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
                 power_9_andup() ? "TRUE" : "FALSE",
                 power_nx_gzip() ? "TRUE" : "FALSE");
         }
-#endif
+        if (setLDR_CNTRL) {
+            const char *ldrCntrlName = "LDR_CNTRL";
+            const char *ldrCntrlValue = "TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K@SHMPSIZE=64K";
+            if (setenv(ldrCntrlName, ldrCntrlValue, 0) != 0) {
+                fprintf(stderr, "setenv('%s=%s') failed: performance may be affected\n",
+                        ldrCntrlName, ldrCntrlValue);
+            } else if (JLI_IsTraceLauncher()) {
+                printf("Set %s=%s\n", ldrCntrlName, ldrCntrlValue);
+            }
+        }
+#endif  /* defined(AIX) */
 
         runpath = getenv(LD_LIBRARY_PATH);
 
@@ -412,10 +427,10 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
             char *new_jvmpath = JLI_StringDup(jvmpath);
             new_runpath_size = ((runpath != NULL) ? JLI_StrLen(runpath) : 0) +
                     2 * JLI_StrLen(jrepath) +
-#ifdef AIX
+#if defined(AIX)
                     /* On AIX P9 or newer with NX accelerator enabled, add the accelerated zlibNX to LIBPATH. */
                     (useZlibNX ? JLI_StrLen(":" ZLIBNX_PATH) : 0) +
-#endif
+#endif /* defined(AIX) */
                     JLI_StrLen(new_jvmpath) + 52;
             new_runpath = JLI_MemAlloc(new_runpath_size);
             newpath = new_runpath + JLI_StrLen(LD_LIBRARY_PATH "=");
@@ -434,16 +449,16 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
                         "%s:"
                         "%s/lib:"
                         "%s/../lib"
-#ifdef AIX
+#if defined(AIX)
                         "%s" /* For zlibNX on eligible AIX systems */
-#endif
+#endif /* defined(AIX) */
                         ,
                         new_jvmpath,
                         jrepath,
                         jrepath
-#ifdef AIX
+#if defined(AIX)
                         , (useZlibNX ? (":" ZLIBNX_PATH) : "")
-#endif
+#endif /* defined(AIX) */
                         );
 
                 JLI_MemFree(new_jvmpath);

--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -23,7 +23,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2020, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2020, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -799,10 +799,10 @@ public class Basic {
      * Remove it from the list of env variables
      */
     private static String removeAixExpectedVars(String vars) {
-        String cleanedVars = vars.replace("AIXTHREAD_GUARDPAGES=0,", "");
-        // OpenJ9 adds MALLOCOPTIONS
-        cleanedVars = cleanedVars.replace("MALLOCOPTIONS=multiheap,considersize,", "");
-        return cleanedVars;
+        // OpenJ9 also adds LDR_CNTRL and MALLOCOPTIONS.
+        return vars.replace("AIXTHREAD_GUARDPAGES=0,", "")
+                   .replace("LDR_CNTRL=TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K@SHMPSIZE=64K,", "")
+                   .replace("MALLOCOPTIONS=multiheap,considersize,", "");
     }
 
     private static String sortByLinesWindowsly(String text) {


### PR DESCRIPTION
By default on AIX, the environment variable `LDR_CNTRL` is set to
  `TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K@SHMPSIZE=64K`
to select page sizes that may improve performance.

Options `-XX:+UseMediumPageSize` and `-XX:-UseMediumPageSize` can be used, respectively, to explicitly enable or disable, setting `LDR_CNTRL`.

Issue: https://github.com/eclipse-openj9/openj9/issues/19052.
Supersedes: #330.
This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1190.