### PR TITLE
Remove platform check in java.security for FIPS profiles

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -82,11 +82,9 @@ security.provider.tbd=Apple
 #endif
 security.provider.tbd=SunPKCS11
 
-#if defined aix-ppc || defined linux-ppc || defined linux-s390 || defined linux-x86 || defined windows
 #
 # Java Restricted Security Mode
 #
-#endif
 #if defined linux-ppc || defined linux-s390 || defined linux-x86
 RestrictedSecurity.NSS.140-2.desc.name = Red Hat Enterprise Linux 8 NSS Cryptographic Module FIPS 140-2
 RestrictedSecurity.NSS.140-2.desc.default = true


### PR DESCRIPTION
This update removes the platform check for the default FIPS profiles. z/OS was missing from this check. Instead of adding z/OS to the check, it makes more sense to remove the check altogether. This will enable the default FIPS profiles for z/OS.

Signed-off-by: Thomas-Ginader <thomas.ginader@ibm.com>