### PR TITLE
Enable the z/OS platform for RestrictedSecurity mode

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -101,7 +101,7 @@ public final class RestrictedSecurity {
                 });
         final List<String> nssSupportedArch = List.of("amd64", "ppc64le", "s390x");
         final List<String> openjceplusCertifiedArch = List.of("amd64", "ppc64", "s390x");
-        final List<String> openjceplusCertifiedOS = List.of("AIX", "Linux", "Windows");
+        final List<String> openjceplusCertifiedOS = List.of("AIX", "Linux", "Windows", "z/OS");
         String osName = props[2];
         String osArch = props[3];
 


### PR DESCRIPTION
As part of the effort to enable FIPS140-3 on z/OS for the Semeru releases, the `openjceplusCertifiedOS` list needs to include z/OS.

Signed-off-by: Thomas-Ginader <thomas.ginader@ibm.com>