### PR TITLE
Fix checking for unrecognised JVM options

### DIFF
--- a/make/autoconf/util.m4
+++ b/make/autoconf/util.m4
@@ -335,7 +335,7 @@ AC_DEFUN([UTIL_ADD_JVM_ARG_IF_OK],
   $ECHO "Check if jvm arg is ok: $1" >&AS_MESSAGE_LOG_FD
   $ECHO "Command: $3 $1 -version" >&AS_MESSAGE_LOG_FD
   OUTPUT=`$3 $1 $USER_BOOT_JDK_OPTIONS -version 2>&1`
-  FOUND_WARN=`$ECHO "$OUTPUT" | $GREP -i "warn\|unrecognised"`
+  FOUND_WARN=`$ECHO "$OUTPUT" | $GREP -E -i "warn|unrecognised"`
   FOUND_VERSION=`$ECHO $OUTPUT | $GREP " version \""`
   if test "x$FOUND_VERSION" != x && test "x$FOUND_WARN" = x; then
     $2="[$]$2 $1"


### PR DESCRIPTION
On z/OS, `grep -E` must be used with a pattern containing `|`.

This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1231.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).