### PR TITLE
Update the exclude list for FIPS profile testing

### DIFF
--- a/test/jdk/ProblemList-FIPS140_2.txt
+++ b/test/jdk/ProblemList-FIPS140_2.txt
@@ -861,6 +861,7 @@ sun/security/provider/SeedGenerator/SeedGeneratorChoice.java https://github.com/
 # All the below hard coded static String keyStoreFile = "keystore"; in the test codes. In FIPS mode, keystore must be NONE.
 
 javax/rmi/ssl/SocketFactoryTest.java https://github.com/eclipse-openj9/openj9/issues/21756 linux-ppc64le,linux-s390x,linux-x64
+javax/rmi/ssl/SslRMIClientSocketFactoryPermissionTest.java https://github.com/eclipse-openj9/openj9/issues/23655 linux-ppc64le,linux-s390x,linux-x64
 sun/security/ssl/AppInputStream/ReadZeroBytes.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-ppc64le,linux-s390x,linux-x64
 sun/security/ssl/AppInputStream/RemoveMarkReset.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-ppc64le,linux-s390x,linux-x64
 sun/security/ssl/AppOutputStream/NoExceptionOnClose.java https://github.com/ibmruntimes/openj9-openjdk-jdk17/issues/131 linux-ppc64le,linux-s390x,linux-x64

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
@@ -279,6 +279,7 @@ java/security/KeyRep/SerialDSAPubKey.java https://github.com/eclipse-openj9/open
 java/security/KeyRep/SerialOld.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/CheckInputStream.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/CheckMacOSKeyChainTrust.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/KeyStore/DisabledKnownType.java https://github.com/eclipse-openj9/openj9/issues/23655 generic-all
 java/security/KeyStore/EntryMethods.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/KeyStoreBuilder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/OneProbeOneNot.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
@@ -508,6 +509,7 @@ javax/net/ssl/SSLEngine/TestAllSuites.java https://github.com/eclipse-openj9/ope
 javax/net/ssl/SSLParameters/NamedGroups.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/SSLParameters/SignatureSchemes.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/SSLParameters/UseCipherSuitesOrder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+javax/net/ssl/SSLSession/CertMsgCheck.java https://github.com/eclipse-openj9/openj9/issues/23655 generic-all
 javax/net/ssl/SSLSession/CheckSessionContext.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/SSLSession/HttpsURLConnectionLocalCertificateChain.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 javax/net/ssl/SSLSession/JSSERenegotiate.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -336,6 +336,7 @@ java/security/KeyRep/SerialDSAPubKey.java https://github.com/eclipse-openj9/open
 java/security/KeyRep/SerialOld.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/CheckInputStream.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/CheckMacOSKeyChainTrust.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+java/security/KeyStore/DisabledKnownType.java https://github.com/eclipse-openj9/openj9/issues/23655 generic-all
 java/security/KeyStore/EntryMethods.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/KeyStoreBuilder.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 java/security/KeyStore/OneProbeOneNot.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all


### PR DESCRIPTION
Add multiple tests to the exclusion list for FIPS 140-2 and FIPS 140-3 profile testing across all JDK versions.

This is a back port PR from PR : https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1236