### PR TITLE
Update the exclude list for FIPS profile testing

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -909,6 +909,8 @@ sun/security/provider/KeyStore/WrongStoreType.java https://github.com/eclipse-op
 sun/security/provider/MessageDigest/DigestKAT.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/MessageDigest/Offsets.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/MessageDigest/TestSHAClone.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/provider/named/NamedEdDSA.java https://github.com/eclipse-openj9/openj9/issues/23655 generic-all
+sun/security/provider/named/NamedKeyFactoryTest.java https://github.com/eclipse-openj9/openj9/issues/23655 generic-all
 sun/security/provider/NamedEdDSA.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/NamedKeyFactoryTest.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/provider/NSASuiteB/TestDSAGenParameterSpec.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
Add multiple tests to the exclusion list for FIPS 140-3 profiles testing across all JDK versions.

This is a back port PR from PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1238