### PR TITLE
Sync up engineGenerateSecret(String) in key agreement classes

### DIFF
--- a/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECDHKeyAgreement.java
+++ b/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeECDHKeyAgreement.java
@@ -61,6 +61,7 @@ import sun.security.ec.point.AffinePoint;
 import sun.security.ec.point.Point;
 import sun.security.util.ArrayUtil;
 import sun.security.util.CurveDB;
+import sun.security.util.KeyUtil;
 import sun.security.util.NamedCurve;
 import sun.security.util.math.ImmutableIntegerModuloP;
 
@@ -347,9 +348,9 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
         if (algorithm == null) {
             throw new NoSuchAlgorithmException("Algorithm must not be null");
         }
-        if (!(algorithm.equals("TlsPremasterSecret"))) {
-            throw new NoSuchAlgorithmException
-                ("Only supported for algorithm TlsPremasterSecret");
+        if (!KeyUtil.isSupportedKeyAgreementOutputAlgorithm(algorithm)) {
+            throw new NoSuchAlgorithmException(
+                    "Unsupported secret key algorithm: " + algorithm);
         }
         byte[] bytes = engineGenerateSecret();
         try {

--- a/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeXDHKeyAgreement.java
+++ b/closed/src/jdk.crypto.ec/share/classes/sun/security/ec/NativeXDHKeyAgreement.java
@@ -50,6 +50,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 import jdk.crypto.jniprovider.NativeCrypto;
 
+import sun.security.util.KeyUtil;
 import sun.security.x509.X509Key;
 
 public class NativeXDHKeyAgreement extends KeyAgreementSpi {
@@ -277,8 +278,9 @@ public class NativeXDHKeyAgreement extends KeyAgreementSpi {
             throw new NoSuchAlgorithmException("Algorithm must not be null");
         }
 
-        if (!(algorithm.equals("TlsPremasterSecret"))) {
-            throw new NoSuchAlgorithmException("Only supported for algorithm TlsPremasterSecret");
+        if (!KeyUtil.isSupportedKeyAgreementOutputAlgorithm(algorithm)) {
+            throw new NoSuchAlgorithmException(
+                    "Unsupported secret key algorithm: " + algorithm);
         }
         byte[] bytes = engineGenerateSecret();
         try {


### PR DESCRIPTION
A check in engineGenerateSecret(String) was updated in ECDHKeyAgreement and XDHKeyAgreement. The equivalent native classes (i.e., NativeECDHKeyAgreement and
NativeXDHKeyAgreement) are updated to reflect that change.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/462

Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/637.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
