### PR TITLE
Update provider handling in Deterministic test

### DIFF
--- a/test/jdk/sun/security/provider/all/Deterministic.java
+++ b/test/jdk/sun/security/provider/all/Deterministic.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 8325506
  * @library /test/lib
@@ -62,7 +68,7 @@ public class Deterministic {
 
         for (var p : Security.getProviders()) {
             var name = p.getName();
-            if (name.equals("SunMSCAPI") || name.startsWith("SunPKCS11")) {
+            if (name.equals("SunMSCAPI") || name.startsWith("SunPKCS11") || name.startsWith("OpenJCEPlus")) {
                 System.out.println("Skipped native provider " + name);
                 continue;
             }
@@ -170,7 +176,7 @@ public class Deterministic {
                 keyAlg = s.getAlgorithm(); // EdDSA etc
             }
         }
-        var sk = generateKeyPair(keyAlg, 0).getPrivate();
+        var sk = generateKeyPair(keyAlg, null, 0).getPrivate();
         var sig = Signature.getInstance(s.getAlgorithm(), s.getProvider());
         try {
             if (keyAlg.equals("RSASSA-PSS")) {
@@ -193,8 +199,8 @@ public class Deterministic {
     static void testKeyPairGenerator(Provider.Service s) throws Exception {
         System.out.println(s.getProvider().getName()
                 + " " + s.getType() + "." + s.getAlgorithm());
-        var kp1 = generateKeyPair(s.getAlgorithm(), 0);
-        var kp2 = generateKeyPair(s.getAlgorithm(), 0);
+        var kp1 = generateKeyPair(s.getAlgorithm(), s.getProvider(), 0);
+        var kp2 = generateKeyPair(s.getAlgorithm(), s.getProvider(), 0);
         Asserts.assertEqualsByteArray(
                 kp1.getPrivate().getEncoded(), kp2.getPrivate().getEncoded());
         Asserts.assertEqualsByteArray(
@@ -205,8 +211,13 @@ public class Deterministic {
         System.out.println("    Passed");
     }
 
-    static KeyPair generateKeyPair(String alg, int offset) throws Exception {
-        var g = KeyPairGenerator.getInstance(alg);
+    static KeyPair generateKeyPair(String alg, Provider provider, int offset) throws Exception {
+        KeyPairGenerator g;
+        if (provider != null) {
+            g = KeyPairGenerator.getInstance(alg, provider);
+        } else {
+            g = KeyPairGenerator.getInstance(alg);
+        }
         var size = switch (g.getAlgorithm()) {
             case "RSA", "RSASSA-PSS", "DSA", "DiffieHellman" -> 1024;
             case "EC" -> 256;
@@ -245,7 +256,7 @@ public class Deterministic {
             g.init(new SeededSecureRandom(SEED + 2));
             return g.generateKey();
         } if (s.equals("RSA")) {
-            return generateKeyPair("RSA", 3).getPublic();
+            return generateKeyPair("RSA", null, 3).getPublic();
         } else {
             var g = KeyGenerator.getInstance(s, p);
             g.init(new SeededSecureRandom(SEED + 4));
@@ -257,7 +268,7 @@ public class Deterministic {
         System.out.println(s.getProvider().getName()
                 + " " + s.getType() + "." + s.getAlgorithm());
         String keyAlg = getKeyAlgFromKEM(s.getAlgorithm());
-        var kp = generateKeyPair(keyAlg, 10);
+        var kp = generateKeyPair(keyAlg, null, 10);
         var kem = KEM.getInstance(s.getAlgorithm(), s.getProvider());
         var e1 = kem.newEncapsulator(kp.getPublic(), null, new SeededSecureRandom(SEED));
         var enc1 = e1.encapsulate();
@@ -274,8 +285,8 @@ public class Deterministic {
         System.out.println(s.getProvider().getName()
                 + " " + s.getType() + "." + s.getAlgorithm());
         String keyAlg = getKeyAlgFromKEM(s.getAlgorithm());
-        var kpS = generateKeyPair(keyAlg, 11);
-        var kpR = generateKeyPair(keyAlg, 12);
+        var kpS = generateKeyPair(keyAlg, null, 11);
+        var kpR = generateKeyPair(keyAlg, null, 12);
         var ka = KeyAgreement.getInstance(s.getAlgorithm(), s.getProvider());
         ka.init(kpS.getPrivate(), new SeededSecureRandom(SEED));
         ka.doPhase(kpR.getPublic(), true);


### PR DESCRIPTION
This update backports changes made to the Deterministic test.

The changes include:

- Skip OpenJCEPlus as it does not support user-provided SecureRandom instances.(#1035)
- Generate key pairs using the provider being tested to avoid unintended provider selection.(#1038)

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1035, https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1038
Signed-off-by: Mohit Rajbhar [mohit.rajbhar@ibm.com](mailto:mohit.rajbhar@ibm.com)

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
